### PR TITLE
Feat/account change automation

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,7 +13,7 @@ connections:
 - valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
 - valory/ledger:0.19.0:bafybeigntoericenpzvwejqfuc3kqzo2pscs76qoygg5dbj6f4zxusru5e
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
-- dvilela/twikit:0.1.0:bafybeih4srbgvtqaisjsphv4gjbfdvrwdkn4ln5k2x3ta7f63qtpmnvlj4
+- dvilela/twikit:0.1.0:bafybeidtv6q6lfu6m6ueyyjmxulodqg7rzje5olwnoai5prx5zuhdcasxe
 - dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
@@ -42,8 +42,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/registration_abci:0.1.0:bafybeib3n6vqkfbrcubcbliebjnuwyywdinxkbzt76n6gbn2kg7ace47dq
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
-- dvilela/memeooorr_abci:0.1.0:bafybeibwtmkw5wnqjulnu5pqnrnzaxnhv47gcyap3ul4gvsawadljn5vom
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeicufuq2knnwt73kautpjmbepwc37ofvriwcuz33sxrjs7b57rrhdi
+- dvilela/memeooorr_abci:0.1.0:bafybeiewccsgdqap3w4hp3fubyrkmdokgzoimyt3oq2zzvozlmbrustk2m
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeia5jse3b3ud7bhjywsfx2jcpg7efa2kyugp4jwzhxz6wye6lcb4da
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,8 +13,8 @@ connections:
 - valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
 - valory/ledger:0.19.0:bafybeigntoericenpzvwejqfuc3kqzo2pscs76qoygg5dbj6f4zxusru5e
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
-- dvilela/twikit:0.1.0:bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y
-- dvilela/mirror_db:0.1.0:bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm
+- dvilela/twikit:0.1.0:bafybeigdhtn2pu2zz3gs4d6aeovri3cbbgxmj5ifvuu4revcnx6liplrry
+- dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 - dvilela/genai:0.1.0:bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy
@@ -42,8 +42,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/registration_abci:0.1.0:bafybeib3n6vqkfbrcubcbliebjnuwyywdinxkbzt76n6gbn2kg7ace47dq
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
-- dvilela/memeooorr_abci:0.1.0:bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeidvod2se6jltarl2b24fxjm272zjzbfz5cvzf25qjs2522oihtsti
+- dvilela/memeooorr_abci:0.1.0:bafybeieaffdkt7lizxfcgnnejnxbmlf7h7atlhzwi7liiwzhy5mb3zeoyi
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeifcbtx4p2jor655wjocq7dy5wyyxzwzjenbkpedau7g6y4bq3acsu
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,8 +13,8 @@ connections:
 - valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
 - valory/ledger:0.19.0:bafybeigntoericenpzvwejqfuc3kqzo2pscs76qoygg5dbj6f4zxusru5e
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
-- dvilela/twikit:0.1.0:bafybeigizuovcsouxozagaqvk3vmo3c53wvmlnlomhpkoisjpg6bibad7u
-- dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
+- dvilela/twikit:0.1.0:bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y
+- dvilela/mirror_db:0.1.0:bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 - dvilela/genai:0.1.0:bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy
@@ -42,8 +42,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/registration_abci:0.1.0:bafybeib3n6vqkfbrcubcbliebjnuwyywdinxkbzt76n6gbn2kg7ace47dq
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
-- dvilela/memeooorr_abci:0.1.0:bafybeidr4asbm3s4kmxmfzdg7zyp3477cgmaq4qrl6sqswrtuhami2tm54
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeihnlzr4mhfdgn24ldeauyu7m4zl5jnn43yn3gpz2clerullxbxegq
+- dvilela/memeooorr_abci:0.1.0:bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeidvod2se6jltarl2b24fxjm272zjzbfz5cvzf25qjs2522oihtsti
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/dvilela/connections/mirror_db/connection.yaml
+++ b/packages/dvilela/connections/mirror_db/connection.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiglyqy5epuu3plwuf4vbvm4kmg2dtohrpmarhbxdr5a27kg32mxku
-  connection.py: bafybeiflgau4wignkfyorehthzxq3zgfkaiizupzccyvqybouivuha3pne
+  connection.py: bafybeierdlumlmecix6cgk3td5boar5r74mfjnjvvywcxz4rbwummltxba
   readme.md: bafybeies7w2qbwrzed4mh72se5n4hbzlucvngb2eseu4giieiiyjjfjdka
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/connections/mirror_db/connection.yaml
+++ b/packages/dvilela/connections/mirror_db/connection.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiglyqy5epuu3plwuf4vbvm4kmg2dtohrpmarhbxdr5a27kg32mxku
-  connection.py: bafybeierdlumlmecix6cgk3td5boar5r74mfjnjvvywcxz4rbwummltxba
+  connection.py: bafybeiflgau4wignkfyorehthzxq3zgfkaiizupzccyvqybouivuha3pne
   readme.md: bafybeies7w2qbwrzed4mh72se5n4hbzlucvngb2eseu4giieiiyjjfjdka
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/connections/twikit/connection.py
+++ b/packages/dvilela/connections/twikit/connection.py
@@ -248,6 +248,7 @@ class TwikitConnection(Connection):
             "follow_user",
             "filter_suspended_users",
             "get_user_by_screen_name",
+            "get_twitter_user_id"
         ]
 
         if not all(i in payload for i in REQUIRED_PROPERTIES):
@@ -463,6 +464,7 @@ class TwikitConnection(Connection):
     
     async def get_twitter_user_id(self) -> str:
         """Returns Twitter ID for the instance Twitter account."""
+        
         if not self.cookies:
             raise ValueError("Cookies are not set.")
         

--- a/packages/dvilela/connections/twikit/connection.py
+++ b/packages/dvilela/connections/twikit/connection.py
@@ -248,7 +248,7 @@ class TwikitConnection(Connection):
             "follow_user",
             "filter_suspended_users",
             "get_user_by_screen_name",
-            "get_twitter_user_id"
+            "get_twitter_user_id",
         ]
 
         if not all(i in payload for i in REQUIRED_PROPERTIES):
@@ -461,17 +461,17 @@ class TwikitConnection(Connection):
         """Get user by screen name"""
         user = await self.client.get_user_by_screen_name(screen_name=screen_name)
         return user_to_json(user)
-    
+
     async def get_twitter_user_id(self) -> str:
         """Returns Twitter ID for the instance Twitter account."""
-        
+
         if not self.cookies:
             raise ValueError("Cookies are not set.")
-        
+
         twid = self.cookies.get("twid", "").strip('"')
         if not twid:
             raise ValueError("Twitter ID (twid) not found in cookies.")
-        
+
         return twid
 
 

--- a/packages/dvilela/connections/twikit/connection.py
+++ b/packages/dvilela/connections/twikit/connection.py
@@ -460,6 +460,17 @@ class TwikitConnection(Connection):
         """Get user by screen name"""
         user = await self.client.get_user_by_screen_name(screen_name=screen_name)
         return user_to_json(user)
+    
+    async def get_twitter_user_id(self) -> str:
+        """Returns Twitter ID for the instance Twitter account."""
+        if not self.cookies:
+            raise ValueError("Cookies are not set.")
+        
+        twid = self.cookies.get("twid", "").strip('"')
+        if not twid:
+            raise ValueError("Twitter ID (twid) not found in cookies.")
+        
+        return twid
 
 
 def tweet_to_json(tweet: Any) -> Dict:

--- a/packages/dvilela/connections/twikit/connection.yaml
+++ b/packages/dvilela/connections/twikit/connection.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiaism4qxp36o6dflr3emtu4hk37dw7evimcoqkvlvt5s42af5lr5m
-  connection.py: bafybeig6ncmd3mlsoyqllyfimlqgilwr77wl7knl23qoxcrad3ib37k25m
+  connection.py: bafybeifhsmfmukmqivdnvo3jzja662fje23fgdnizqv7qdt52f7ngg6tsy
   readme.md: bafybeihl7k3yi3twtvlkjntaknmib6hnhmyjurn25c4nksffcagrwkx5t4
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/connections/twikit/connection.yaml
+++ b/packages/dvilela/connections/twikit/connection.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiaism4qxp36o6dflr3emtu4hk37dw7evimcoqkvlvt5s42af5lr5m
-  connection.py: bafybeibyoyf2oatmu4ktotbrbhuoe4gzcbbq3fzqfgisirhadrefp4r4cm
+  connection.py: bafybeieeuvy4qvrexgthtv23bp7axu5uvo33rezpeualruebqz5hjeg7j4
   readme.md: bafybeihl7k3yi3twtvlkjntaknmib6hnhmyjurn25c4nksffcagrwkx5t4
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/connections/twikit/connection.yaml
+++ b/packages/dvilela/connections/twikit/connection.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiaism4qxp36o6dflr3emtu4hk37dw7evimcoqkvlvt5s42af5lr5m
-  connection.py: bafybeib4dyrcjdmocduhxvwihlucp2cucxz7kufuyxevmoamebycl3akwm
+  connection.py: bafybeibyoyf2oatmu4ktotbrbhuoe4gzcbbq3fzqfgisirhadrefp4r4cm
   readme.md: bafybeihl7k3yi3twtvlkjntaknmib6hnhmyjurn25c4nksffcagrwkx5t4
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeig3tocoat2fipax6huatfyt5dnjalz5fog5zbycfud7s7wst3qqpa
+agent: dvilela/memeooorr:0.1.0:bafybeiehaovfb6stxwvoaqtf4go775ypnkyv6ua4p23fvlqnqatdway4u4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeihm46rbu3do3eapg4etuv7k3yfpdaksitda64ow5gjvqldedaknza
+agent: dvilela/memeooorr:0.1.0:bafybeid4rdutsffhexa6uxde5ekbw6kxrbmmqfnbd5pdmmn6pzoxggz6v4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeihwe7zcehq3oqt3dw6xpi3dxvbzhr762ihgvksvoxr32q3i5wmccq
+agent: dvilela/memeooorr:0.1.0:bafybeihm46rbu3do3eapg4etuv7k3yfpdaksitda64ow5gjvqldedaknza
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeifd6cym2i5xhk4toahru6jhnv5czm42qjrjys4r5dpdrzn7jkroym
+  behaviour_classes/base.py: bafybeihgp24r4e2d4knrkkz6vzr533savydkcy6gstlefu6ojexm7ypirq
   behaviour_classes/chain.py: bafybeieuf6l7bd4dqw3jgt5cjxflxbb5lcysgymef2wjcj3uzpojn3msv4
   behaviour_classes/db.py: bafybeidbonkoclqbf6liz2fcvcs3lvhflqibrqthacggya6lvqpbpgck2a
   behaviour_classes/llm.py: bafybeibbukixayipuhqcxfh3z6jjel3ny6enh7sf72ppck4w5vyfd34ltq
@@ -25,8 +25,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
-- dvilela/twikit:0.1.0:bafybeigizuovcsouxozagaqvk3vmo3c53wvmlnlomhpkoisjpg6bibad7u
-- dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
+- dvilela/twikit:0.1.0:bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y
+- dvilela/mirror_db:0.1.0:bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm
 - dvilela/genai:0.1.0:bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 contracts:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeihgp24r4e2d4knrkkz6vzr533savydkcy6gstlefu6ojexm7ypirq
+  behaviour_classes/base.py: bafybeidy6ax4muizoohluh5tbypifa5os36itmyxmpo2trj7uvod64m5tq
   behaviour_classes/chain.py: bafybeieuf6l7bd4dqw3jgt5cjxflxbb5lcysgymef2wjcj3uzpojn3msv4
   behaviour_classes/db.py: bafybeidbonkoclqbf6liz2fcvcs3lvhflqibrqthacggya6lvqpbpgck2a
   behaviour_classes/llm.py: bafybeibbukixayipuhqcxfh3z6jjel3ny6enh7sf72ppck4w5vyfd34ltq
@@ -25,8 +25,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
-- dvilela/twikit:0.1.0:bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y
-- dvilela/mirror_db:0.1.0:bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm
+- dvilela/twikit:0.1.0:bafybeigdhtn2pu2zz3gs4d6aeovri3cbbgxmj5ifvuu4revcnx6liplrry
+- dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
 - dvilela/genai:0.1.0:bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 contracts:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeibgzymk4p4462nbufdgotjxduh2qjaqrkwc7hrkz2k4ig7m3ze2lu
+  behaviour_classes/base.py: bafybeidqu4cdnu7a74ha4cvzsxhleildu7porsns4q5674pmiauonmyptq
   behaviour_classes/chain.py: bafybeieuf6l7bd4dqw3jgt5cjxflxbb5lcysgymef2wjcj3uzpojn3msv4
   behaviour_classes/db.py: bafybeidbonkoclqbf6liz2fcvcs3lvhflqibrqthacggya6lvqpbpgck2a
   behaviour_classes/llm.py: bafybeibfx3xrqoijvy5rkkkmmmlnk5udfluv42xxeqn5xpdygbov2jc7au
@@ -25,7 +25,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeiekugvb2kan4342hliluxl3h5och3fjwqoafdyttpcn57evvyztq4
-- dvilela/twikit:0.1.0:bafybeih4srbgvtqaisjsphv4gjbfdvrwdkn4ln5k2x3ta7f63qtpmnvlj4
+- dvilela/twikit:0.1.0:bafybeidtv6q6lfu6m6ueyyjmxulodqg7rzje5olwnoai5prx5zuhdcasxe
 - dvilela/mirror_db:0.1.0:bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/termination_abci:0.1.0:bafybeifi2uodnrjsrivj53g3sjutocmyusbx6mlsb6oanqdyt2mfbyvusy
-- dvilela/memeooorr_abci:0.1.0:bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y
+- dvilela/memeooorr_abci:0.1.0:bafybeieaffdkt7lizxfcgnnejnxbmlf7h7atlhzwi7liiwzhy5mb3zeoyi
 behaviours:
   main:
     args: {}

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/termination_abci:0.1.0:bafybeifi2uodnrjsrivj53g3sjutocmyusbx6mlsb6oanqdyt2mfbyvusy
-- dvilela/memeooorr_abci:0.1.0:bafybeibwtmkw5wnqjulnu5pqnrnzaxnhv47gcyap3ul4gvsawadljn5vom
+- dvilela/memeooorr_abci:0.1.0:bafybeiewccsgdqap3w4hp3fubyrkmdokgzoimyt3oq2zzvozlmbrustk2m
 behaviours:
   main:
     args: {}

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihkj6lmaypspyxe5qqrjgnolyck62pyvqoylr24ab6ue4steqcw7e
 - valory/transaction_settlement_abci:0.1.0:bafybeigh2vkt74jrad5gtsczrgqcuhcqe7jkgjy7jdw56yamlzwwnaymjy
 - valory/termination_abci:0.1.0:bafybeifi2uodnrjsrivj53g3sjutocmyusbx6mlsb6oanqdyt2mfbyvusy
-- dvilela/memeooorr_abci:0.1.0:bafybeidr4asbm3s4kmxmfzdg7zyp3477cgmaq4qrl6sqswrtuhami2tm54
+- dvilela/memeooorr_abci:0.1.0:bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y
 behaviours:
   main:
     args: {}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,13 +2,13 @@
     "dev": {
         "contract/dvilela/meme_factory/0.1.0": "bafybeiawl5cqtlbm7vrh7ah3iubzjh7ycjhem27xz24ssyhnwnmqaunwee",
         "contract/dvilela/service_registry/0.1.0": "bafybeie2rrgzcjehlp2feff6bhkuindxzrnuwxe2jcrsy2thcdtrsp2o24",
-        "connection/dvilela/twikit/0.1.0": "bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y",
-        "connection/dvilela/mirror_db/0.1.0": "bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm",
+        "connection/dvilela/twikit/0.1.0": "bafybeigdhtn2pu2zz3gs4d6aeovri3cbbgxmj5ifvuu4revcnx6liplrry",
+        "connection/dvilela/mirror_db/0.1.0": "bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu",
         "connection/dvilela/genai/0.1.0": "bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeidvod2se6jltarl2b24fxjm272zjzbfz5cvzf25qjs2522oihtsti",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeihm46rbu3do3eapg4etuv7k3yfpdaksitda64ow5gjvqldedaknza",
-        "service/dvilela/memeooorr/0.1.0": "bafybeieq62weee5dveht4y2jlt3mg2bppwh7tf7lxoqnksk2gblijazoyi"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeieaffdkt7lizxfcgnnejnxbmlf7h7atlhzwi7liiwzhy5mb3zeoyi",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifcbtx4p2jor655wjocq7dy5wyyxzwzjenbkpedau7g6y4bq3acsu",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeid4rdutsffhexa6uxde5ekbw6kxrbmmqfnbd5pdmmn6pzoxggz6v4",
+        "service/dvilela/memeooorr/0.1.0": "bafybeieua73newnppfkopn5feszxa7d4hy6rtwcrhks4gbwlodpn5uwcgy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,13 +2,13 @@
     "dev": {
         "contract/dvilela/meme_factory/0.1.0": "bafybeiawl5cqtlbm7vrh7ah3iubzjh7ycjhem27xz24ssyhnwnmqaunwee",
         "contract/dvilela/service_registry/0.1.0": "bafybeie2rrgzcjehlp2feff6bhkuindxzrnuwxe2jcrsy2thcdtrsp2o24",
-        "connection/dvilela/twikit/0.1.0": "bafybeih4srbgvtqaisjsphv4gjbfdvrwdkn4ln5k2x3ta7f63qtpmnvlj4",
+        "connection/dvilela/twikit/0.1.0": "bafybeidtv6q6lfu6m6ueyyjmxulodqg7rzje5olwnoai5prx5zuhdcasxe",
         "connection/dvilela/mirror_db/0.1.0": "bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeibwtmkw5wnqjulnu5pqnrnzaxnhv47gcyap3ul4gvsawadljn5vom",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeicufuq2knnwt73kautpjmbepwc37ofvriwcuz33sxrjs7b57rrhdi",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeig3tocoat2fipax6huatfyt5dnjalz5fog5zbycfud7s7wst3qqpa",
-        "service/dvilela/memeooorr/0.1.0": "bafybeigpemq6ox45mtwtz34zdma5hsv6zqcqnggzjf3gqgk6yy2lywmena"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiewccsgdqap3w4hp3fubyrkmdokgzoimyt3oq2zzvozlmbrustk2m",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeia5jse3b3ud7bhjywsfx2jcpg7efa2kyugp4jwzhxz6wye6lcb4da",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiehaovfb6stxwvoaqtf4go775ypnkyv6ua4p23fvlqnqatdway4u4",
+        "service/dvilela/memeooorr/0.1.0": "bafybeifdp6gaihsbhbox4bt4brems5i25ce2aihjtymv77vg6sxfiq7mx4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,13 +2,13 @@
     "dev": {
         "contract/dvilela/meme_factory/0.1.0": "bafybeiawl5cqtlbm7vrh7ah3iubzjh7ycjhem27xz24ssyhnwnmqaunwee",
         "contract/dvilela/service_registry/0.1.0": "bafybeie2rrgzcjehlp2feff6bhkuindxzrnuwxe2jcrsy2thcdtrsp2o24",
-        "connection/dvilela/twikit/0.1.0": "bafybeigizuovcsouxozagaqvk3vmo3c53wvmlnlomhpkoisjpg6bibad7u",
-        "connection/dvilela/mirror_db/0.1.0": "bafybeiflmyk4szmeawil7ibpis4o53mn5gcvcemj5g6yy2l6c4b4j2vufu",
+        "connection/dvilela/twikit/0.1.0": "bafybeih2oynnfahgllrkpfyecidhcqngfkfitmscrclsaxhbqiklpnhi5y",
+        "connection/dvilela/mirror_db/0.1.0": "bafybeickfkdms52ftuxtrrue3oakmoj3gb2wln7m7uzjpdpxpnrjwm7vtm",
         "connection/dvilela/genai/0.1.0": "bafybeidkxxlonrxirznivkmzc34wmby4e4s57rfg2b7k6xyos23g3y6cdy",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidr4asbm3s4kmxmfzdg7zyp3477cgmaq4qrl6sqswrtuhami2tm54",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihnlzr4mhfdgn24ldeauyu7m4zl5jnn43yn3gpz2clerullxbxegq",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeihwe7zcehq3oqt3dw6xpi3dxvbzhr762ihgvksvoxr32q3i5wmccq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeigo3nyl3eu3nldsiucoxy4vuc6irsmbuuozohjon6ikekbxpj2peq"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiegw2f3kdjldorzitelmgrzspgjiw2pdsx3nksj2hdcqmzdhnms6y",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeidvod2se6jltarl2b24fxjm272zjzbfz5cvzf25qjs2522oihtsti",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeihm46rbu3do3eapg4etuv7k3yfpdaksitda64ow5gjvqldedaknza",
+        "service/dvilela/memeooorr/0.1.0": "bafybeieq62weee5dveht4y2jlt3mg2bppwh7tf7lxoqnksk2gblijazoyi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",


### PR DESCRIPTION
This PR introduces automatic Twitter account switching in case of suspension. It also registers the new account with mirrorDB.

The process works by detecting changes in the Twitter cookie and comparing it with the stored `twitter_id` in `mirrod_db_config`. If there's a mismatch, the system automatically switches to the new account.