### PR TITLE
Fix KeyError in get_packages method

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -44,8 +44,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
 - valory/registration_abci:0.1.0:bafybeifaa6ejpihwxxxswqd5qfy63rixml43d3ljnezilflvdtclspjj6y
 - valory/reset_pause_abci:0.1.0:bafybeigebq46oqz2mx2iajupr6p5pgm6z5pvfye5w6zypsseuqtvta7b4a
-- dvilela/memeooorr_abci:0.1.0:bafybeiafjlcs7m3cetz2lcxhin7zbh2rtl2mg52cf5vha7ybh63wk3xviu
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeiggpzgzfiwfb6fici7pdcl3un42homcl5pukw2jkfkl7qjtclxrv4
+- dvilela/memeooorr_abci:0.1.0:bafybeif3vxgyqlammphzhpve7tpg5sbjbejvyyo3s4zmktiunljzub6ryq
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeifdun4joptc4is7xihfnsic27vyvpqlarojclovrzc47hx3edffxu
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeidn7ayus7q7bjl25xy5gyuuzog3mrykicyx4wa6qt4e5o6w25e3qy
+agent: dvilela/memeooorr:0.1.0:bafybeiga7iqrohjifhnaklj6logryupw3pmhvsgpl36qqospn3kjvutz34
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -826,8 +826,17 @@ class MemeooorrBaseBehaviour(
             )
             return None
 
-        response_json = json.loads(response.body)["data"]  # type: ignore
-        return response_json
+        # Parse the response body
+        response_body = json.loads(response.body)  # type: ignore
+
+        # Check if 'data' key exists in the response
+        if "data" not in response_body:
+            self.context.logger.error(
+                f"Expected 'data' key in response, but got: {response_body}"
+            )
+            return None
+
+        return response_body["data"]
 
     def get_memeooorr_handles_from_subgraph(self) -> Generator[None, None, List[str]]:
         """Get Memeooorr service handles"""

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeia34tmkof6pprnsuovywixxa3llyi6g7ki2mxfimcnp7v6x7cdwny
+  behaviour_classes/base.py: bafybeictycy6g4xvkbgdh5dbxwg4qi4ebpnzkqd6ayqg4repfv6wuyi7vu
   behaviour_classes/chain.py: bafybeianlgx76tkdoyx3giz2bs5oreb5duietjw4bnwnw5ob76ul4klt5m
   behaviour_classes/db.py: bafybeidbonkoclqbf6liz2fcvcs3lvhflqibrqthacggya6lvqpbpgck2a
   behaviour_classes/llm.py: bafybeia6pr7dzvrx4hdns2xhfz3s323oz5jfboy3x2f7tnbch6pnafihwy

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigebq46oqz2mx2iajupr6p5pgm6z5pvfye5w6zypsseuqtvta7b4a
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
 - valory/termination_abci:0.1.0:bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu
-- dvilela/memeooorr_abci:0.1.0:bafybeiafjlcs7m3cetz2lcxhin7zbh2rtl2mg52cf5vha7ybh63wk3xviu
+- dvilela/memeooorr_abci:0.1.0:bafybeif3vxgyqlammphzhpve7tpg5sbjbejvyyo3s4zmktiunljzub6ryq
 behaviours:
   main:
     args: {}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -45,6 +45,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeia27qmw6w5ds5fcrpj2475brnz742aampe3sgochloijs2l7jovai",
         "skill/valory/termination_abci/0.1.0": "bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihjuw2sgujpninxmg4v6dthlivjf3amczlib6ndj7dr34rnmhzboa"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeicgdtoq5dwr5plqcxd3nfjuaf2abh7d3tqzv6e576wloszmyxueom"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,10 +8,10 @@
         "connection/dvilela/mirror_db/0.1.0": "bafybeifhl7e5odr53pbz2bog3tysyyfnimrz2acksgnal4yza4faxam6pa",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiafjlcs7m3cetz2lcxhin7zbh2rtl2mg52cf5vha7ybh63wk3xviu",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeiggpzgzfiwfb6fici7pdcl3un42homcl5pukw2jkfkl7qjtclxrv4",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeidn7ayus7q7bjl25xy5gyuuzog3mrykicyx4wa6qt4e5o6w25e3qy",
-        "service/dvilela/memeooorr/0.1.0": "bafybeihjebj23iu46rhb3koywllwsg4aaiwdgfwzazo22gaemo3ttk7kwi"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeif3vxgyqlammphzhpve7tpg5sbjbejvyyo3s4zmktiunljzub6ryq",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifdun4joptc4is7xihfnsic27vyvpqlarojclovrzc47hx3edffxu",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiga7iqrohjifhnaklj6logryupw3pmhvsgpl36qqospn3kjvutz34",
+        "service/dvilela/memeooorr/0.1.0": "bafybeiblezvojcakqdr5fkogwmudoqanzgjbvzglp624pjzpvoyluaygeu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",
@@ -45,6 +45,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeia27qmw6w5ds5fcrpj2475brnz742aampe3sgochloijs2l7jovai",
         "skill/valory/termination_abci/0.1.0": "bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihjuw2sgujpninxmg4v6dthlivjf3amczlib6ndj7dr34rnmhzboa"
     }
 }


### PR DESCRIPTION
## Fix KeyError in `get_packages` method

## Description
This PR fixes a bug in the `get_packages` method that was causing a KeyError when trying to access the 'data' key in the response JSON from the Olas subgraph. The error occurred because the method was not checking if the 'data' key exists before attempting to access it.

## Changes
- Added proper error checking to verify that the 'data' key exists in the response before accessing it
- Added detailed error logging to provide better diagnostics when the response format is unexpected
- Improved error handling to return None gracefully instead of throwing an exception
