### PR TITLE
a bugfix for quote tweet

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,7 +13,7 @@ connections:
 - valory/http_client:0.23.0:bafybeid5ffvg76ejjoese7brj5ji3lx66cu7p2ixfwflpo6rgofkypfd7y
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
-- dvilela/tweepy:0.1.0:bafybeicdnzzzzyttvprfxnioiixuzwxqwc3rcsx3fmfc24b7zr64mztpe4
+- dvilela/tweepy:0.1.0:bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu
 - dvilela/kv_store:0.1.0:bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeibgfqceer5g423vm4quoxdfy26omlcbvfztlb2iojncho2mcu7zre
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeiafyfqhdx2dtyjv3j3uhuga6bb6nhivq66abhrq3xs7ei73ujraza
+- dvilela/memeooorr_abci:0.1.0:bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeihcix3cthdwyrisyut5nzz7kztsggjfbylcemuyecfrr37nos6jwu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidr3udnfofgmrzeogiuxhfz4hlprnyfdhctp6pwm3jufmovir7gom
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,7 +13,7 @@ connections:
 - valory/http_client:0.23.0:bafybeid5ffvg76ejjoese7brj5ji3lx66cu7p2ixfwflpo6rgofkypfd7y
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
-- dvilela/tweepy:0.1.0:bafybeiekwzgpnkxfprzqvbhvb3y6l5eovd2r6nem552ipyyjr5tudvphi4
+- dvilela/tweepy:0.1.0:bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu
 - dvilela/kv_store:0.1.0:bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeifqrqua4u2xoafsqzffjh35kjou4czja6ctvtqxwvqzwwza7ngesa
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeifzdhfwjviv7egn32lhmhvop4hda7prvmcv2n32nipttm6tymvhvi
+- dvilela/memeooorr_abci:0.1.0:bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeihcix3cthdwyrisyut5nzz7kztsggjfbylcemuyecfrr37nos6jwu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidr3udnfofgmrzeogiuxhfz4hlprnyfdhctp6pwm3jufmovir7gom
 default_ledger: ethereum

--- a/packages/dvilela/connections/tweepy/connection.py
+++ b/packages/dvilela/connections/tweepy/connection.py
@@ -265,6 +265,7 @@ class TweepyConnection(BaseSyncConnection):
                 text=tweet_kwargs["text"],
                 image_paths=tweet_kwargs.get("image_paths", None),
                 in_reply_to_tweet_id=tweet_kwargs.get("reply_to", None),
+                quote_tweet_id=tweet_kwargs.get("quote_tweet_id", None),
             )
             tweet_ids.append(tweet_id)
             is_first_tweet = False

--- a/packages/dvilela/connections/tweepy/connection.yaml
+++ b/packages/dvilela/connections/tweepy/connection.yaml
@@ -7,9 +7,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeicrwqrdownfmeyvvzu45fllxouiwvtynrzs5fhbpt3wndyyhn66eu
-  connection.py: bafybeiazpwe742wiicnvju5pkjbvrt77vmnwvrg2cccd7wbg2devy2qg4y
+  connection.py: bafybeienxlo7bkj57niiotqm3zo4sagioygdwk3ewlmzgozpi7bte6sucm
   readme.md: bafybeib5oflnp3gymrottersu6qrnitjmaifl2gvbvjq7kbmsdbihhzfaa
-  tweepy_wrapper.py: bafybeidl2ek3mtd3ueuxuxs7gmkgqtfk54g6y2v6ie5azqo6mkm6xxaf5m
+  tweepy_wrapper.py: bafybeia6a7bfbgwjaick4awzqpe5nahzgqrfnlsnfz2o7rpgsdmb6ymqly
 fingerprint_ignore_patterns: []
 connections: []
 protocols:

--- a/packages/dvilela/connections/tweepy/connection.yaml
+++ b/packages/dvilela/connections/tweepy/connection.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeicrwqrdownfmeyvvzu45fllxouiwvtynrzs5fhbpt3wndyyhn66eu
   connection.py: bafybeienxlo7bkj57niiotqm3zo4sagioygdwk3ewlmzgozpi7bte6sucm
   readme.md: bafybeib5oflnp3gymrottersu6qrnitjmaifl2gvbvjq7kbmsdbihhzfaa
-  tweepy_wrapper.py: bafybeidoxonod3w3lpacgxx3fckyefv3ulf435b6tsjtds2v6df4tu2xsu
+  tweepy_wrapper.py: bafybeia6a7bfbgwjaick4awzqpe5nahzgqrfnlsnfz2o7rpgsdmb6ymqly
 fingerprint_ignore_patterns: []
 connections: []
 protocols:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeicyhg5zv6zyklylkt6rv7e7pgdry53jlzrbwl3k4tbsqtm5vl2fiq
+agent: dvilela/memeooorr:0.1.0:bafybeiaehbmhk3wt7k52ljp6qxqrtug4ni52ebwe7qszsakc3ffyqwoj6m
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeiabjbqvan44o34sovhctrvgnocjdqtnwq25s7gccxegvpccntueke
+agent: dvilela/memeooorr:0.1.0:bafybeiaehbmhk3wt7k52ljp6qxqrtug4ni52ebwe7qszsakc3ffyqwoj6m
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -201,9 +201,9 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
         }
 
         if quote_tweet_id:  # If a quote ID for DB storage is provided
-            post_action_params["quote_url"] = (
-                quote_tweet_id  # we have defined the quote_url in the DB model/schema so we need to use quote_url instead of quote_tweet_id
-            )
+            post_action_params[
+                "quote_url"
+            ] = quote_tweet_id  # we have defined the quote_url in the DB model/schema so we need to use quote_url instead of quote_tweet_id
         elif original_tweet_id_for_reply:
             post_action_params["reply_to_tweet_id"] = str(original_tweet_id_for_reply)
 

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -201,7 +201,9 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
         }
 
         if quote_tweet_id:  # If a quote ID for DB storage is provided
-            post_action_params["quote_tweet_id"] = quote_tweet_id
+            post_action_params["quote_url"] = (
+                quote_tweet_id  # we have defined the quote_url in the DB model/schema so we need to use quote_url instead of quote_tweet_id
+            )
         elif original_tweet_id_for_reply:
             post_action_params["reply_to_tweet_id"] = str(original_tweet_id_for_reply)
 

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -165,7 +165,7 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
         tweet_payload: Dict[str, Any],
         action_text: str,
         original_tweet_id_for_reply: Optional[str] = None,
-        quote_url_for_storage: Optional[str] = None,
+        quote_tweet_id: Optional[str] = None,
         store_in_kv: bool = True,  # Default for KV store of main posts
     ) -> Generator[None, None, Optional[Union[Dict, bool]]]:
         """Helper to post new content (original tweet, reply, quote) to Twitter."""
@@ -174,18 +174,20 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
         )
 
         # Determine if this is a reply or quote based on provided parameters
-        is_reply_or_quote_action = bool(
-            original_tweet_id_for_reply or quote_url_for_storage
-        )
+        is_reply_or_quote_action = bool(original_tweet_id_for_reply or quote_tweet_id)
 
         tweet_ids = yield from self._call_tweepy(
             method="post",
             tweets=[tweet_payload],
         )
 
-        if not tweet_ids or tweet_ids[0] is None:
+        # Check if tweet_ids is a list and has at least one valid element.
+        # It can be a dictionary if _call_tweepy returns a structured error from the connection
+        # (placed within the "response" field of the connection's payload).
+        if not isinstance(tweet_ids, list) or not tweet_ids or tweet_ids[0] is None:
             self.context.logger.error(
-                f"Failed {log_message_prefix.lower()} to Twitter."
+                f"Failed {log_message_prefix.lower()} to Twitter. "
+                f"Unexpected or unsuccessful response from Tweepy call: {tweet_ids}"
             )
             # Return None if it was intended as a main post (not reply/quote) but failed, else False
             return None if not is_reply_or_quote_action else False
@@ -198,8 +200,8 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
             "timestamp": datetime.now(timezone.utc),
         }
 
-        if quote_url_for_storage:  # Quote takes precedence if both somehow provided
-            post_action_params["quote_url"] = quote_url_for_storage
+        if quote_tweet_id:  # If a quote ID for DB storage is provided
+            post_action_params["quote_tweet_id"] = quote_tweet_id
         elif original_tweet_id_for_reply:
             post_action_params["reply_to_tweet_id"] = str(original_tweet_id_for_reply)
 
@@ -252,7 +254,7 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
                 tweet_payload=tweet_payload_for_api,
                 action_text=text_to_post,  # The text component for DB/KV
                 original_tweet_id_for_reply=None,
-                quote_url_for_storage=None,
+                quote_tweet_id=None,
                 store_in_kv=store,
             )
         )
@@ -262,31 +264,34 @@ class BaseTweetBehaviour(MemeooorrBaseBehaviour):  # pylint: disable=too-many-an
         tweet_id: str,  # ID of the tweet being replied to/quoted
         text: str,
         quote: bool = False,
-        user_name: Optional[str] = None,  # User name for quote URL
+        user_name: Optional[
+            str
+        ] = None,  # User name for quote URL (no longer used for URL construction here)
     ) -> Generator[None, None, bool]:
         """Respond to a tweet (reply or quote)."""
         log_prefix = "Quoting tweet" if quote else "Replying to tweet"
 
         tweet_payload_for_api = {"text": text}
-        quote_url_for_storage_val: Optional[str] = None
+        id_of_tweet_being_quoted_for_db: Optional[str] = None
 
         if quote:
             if not user_name:
-                self.context.logger.error("User name is required for quoting a tweet.")
-                return False
+                self.context.logger.error(
+                    "User name is required for quoting a tweet contextually."
+                )
+                # Depending on strictness, could return False. For now, proceed with quote if tweet_id is present.
             tweet_payload_for_api["quote_tweet_id"] = tweet_id
-            quote_url_for_storage_val = f"https://x.com/{user_name}/status/{tweet_id}"
+            id_of_tweet_being_quoted_for_db = tweet_id
         else:
-            tweet_payload_for_api["reply_to"] = tweet_id
+            tweet_payload_for_api["in_reply_to_tweet_id"] = tweet_id
 
         result = yield from self._create_twitter_content(
             log_message_prefix=log_prefix,
             tweet_payload=tweet_payload_for_api,
             action_text=text,
             original_tweet_id_for_reply=tweet_id if not quote else None,
-            quote_url_for_storage=quote_url_for_storage_val,
-            # store_in_kv is not passed, defaults to True in _create_twitter_content,
-            # but the 'if not is_reply_or_quote:' block handles it correctly.
+            quote_tweet_id=id_of_tweet_being_quoted_for_db if quote else None,
+            store_in_kv=True,
         )
         return bool(result)
 

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -26,7 +26,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu
-- dvilela/tweepy:0.1.0:bafybeicdnzzzzyttvprfxnioiixuzwxqwc3rcsx3fmfc24b7zr64mztpe4
+- dvilela/tweepy:0.1.0:bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 contracts:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
   behaviour_classes/mech.py: bafybeig5r6w7yjg26tj6m2khikqjtkcva6sojef6pdjrfnpmfwdqgfkavm
-  behaviour_classes/twitter.py: bafybeifdsgnhkq5wnzvbktluuwfjjgkf3fc6pcu4fk7smxrqtahf7364my
+  behaviour_classes/twitter.py: bafybeihzmzf3odhtlwqp5i2ycaudzl5tth6webifp2w65wcstoql5mvtqq
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
@@ -26,7 +26,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu
-- dvilela/tweepy:0.1.0:bafybeiekwzgpnkxfprzqvbhvb3y6l5eovd2r6nem552ipyyjr5tudvphi4
+- dvilela/tweepy:0.1.0:bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 contracts:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeifqrqua4u2xoafsqzffjh35kjou4czja6ctvtqxwvqzwwza7ngesa
+- dvilela/memeooorr_abci:0.1.0:bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeibgfqceer5g423vm4quoxdfy26omlcbvfztlb2iojncho2mcu7zre
+- dvilela/memeooorr_abci:0.1.0:bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu",
-        "connection/dvilela/tweepy/0.1.0": "bafybeiekwzgpnkxfprzqvbhvb3y6l5eovd2r6nem552ipyyjr5tudvphi4",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeifqrqua4u2xoafsqzffjh35kjou4czja6ctvtqxwvqzwwza7ngesa",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifzdhfwjviv7egn32lhmhvop4hda7prvmcv2n32nipttm6tymvhvi",
+        "connection/dvilela/tweepy/0.1.0": "bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihcix3cthdwyrisyut5nzz7kztsggjfbylcemuyecfrr37nos6jwu",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidr3udnfofgmrzeogiuxhfz4hlprnyfdhctp6pwm3jufmovir7gom",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeicyhg5zv6zyklylkt6rv7e7pgdry53jlzrbwl3k4tbsqtm5vl2fiq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeifb2s6f3ebqhj3fl7yjvcqktgwp55gdwejd7m3al35gqtytaczjwi"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiaehbmhk3wt7k52ljp6qxqrtug4ni52ebwe7qszsakc3ffyqwoj6m",
+        "service/dvilela/memeooorr/0.1.0": "bafybeibeyvkwki5pw3z3us53yinprflh2tbi6utg3ubt3365htijokpwhq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeiecnl7yc5qx6x4q7467i66ehmfw4qydnnry7tjs7plqeytb6ueyvu",
-        "connection/dvilela/tweepy/0.1.0": "bafybeicdnzzzzyttvprfxnioiixuzwxqwc3rcsx3fmfc24b7zr64mztpe4",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeibgfqceer5g423vm4quoxdfy26omlcbvfztlb2iojncho2mcu7zre",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeiafyfqhdx2dtyjv3j3uhuga6bb6nhivq66abhrq3xs7ei73ujraza",
+        "connection/dvilela/tweepy/0.1.0": "bafybeicf5c2ctlomhkmzh47p3xxrkamparsupbmbgy6nf2bix6xuo4uxeu",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeibxildor5gs5lyaqguqzt72tnp2mkrwnicuntdarbzllhb625hrg4",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihcix3cthdwyrisyut5nzz7kztsggjfbylcemuyecfrr37nos6jwu",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidr3udnfofgmrzeogiuxhfz4hlprnyfdhctp6pwm3jufmovir7gom",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeiabjbqvan44o34sovhctrvgnocjdqtnwq25s7gccxegvpccntueke",
-        "service/dvilela/memeooorr/0.1.0": "bafybeigpyuftf2nizxibxtsocwzwj57mnm7r2nobth4a3qvavgkcyl4r34"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiaehbmhk3wt7k52ljp6qxqrtug4ni52ebwe7qszsakc3ffyqwoj6m",
+        "service/dvilela/memeooorr/0.1.0": "bafybeibeyvkwki5pw3z3us53yinprflh2tbi6utg3ubt3365htijokpwhq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     open-aea-cli-ipfs==1.65.0
     open-aea-test-autonomy==0.19.7
     toml==0.10.2
-    typing_extensions>=3.10.0.2
+    typing_extensions==4.13.0
     tweepy==4.14.0
     twitter_text_parser==3.0.0
     peewee==3.17.5
@@ -601,3 +601,4 @@ mypy-extensions: *
 setuptools: *
 click: >=8.2.0
 typing-inspection: *
+uritemplate: *


### PR DESCRIPTION
1. The post tweet fn was missing quote_tweet_id param added it inside the tweepy_wrapper
2. made corresponding changes required in tweepy
3. slightly improved post tweet media id structure as suggested by black formatter
4. we do not need to store the quote_URL anymore since the tweepy requires quote_id(tweet_id)
5. but in the agents_db we have the attribute definition set and it contains quote_url key (unfortunately we cannot change it) so from now on quote_url will have quote_id instead in agents_db