### PR TITLE
Tweaking LLM prompts to introduce entropy in Agent actions

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeib3n6f7gxnkfe66pabg2hjdfzvrvgzj46jeejcuap7zudtwnbgoza
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeihpv7ks6wh67y4a2drkc3obhzmohplqmp2njzerd4tjaumsvdnnlu
+- dvilela/memeooorr_abci:0.1.0:bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeih2qydhqx7yiesrfcxnbzc3rg5iyyz4r3ciwswx3wnsxo2oa3p4yy
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeiflqrbpbevteriivevm2uhu5aypcoi3k7p6aipz7nw2hhax77xmai
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeih2qydhqx7yiesrfcxnbzc3rg5iyyz4r3ciwswx3wnsxo2oa3p4yy
+- dvilela/memeooorr_abci:0.1.0:bafybeidfuko4vlaaiarivm3b4xbrfvi2wnzamnncmd42j446lrycdeqjeu
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeihxbnhjepkonb27cmdez3e3na5vypvsyy7sus2ogscih5qj5g5moy
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeiflqrbpbevteriivevm2uhu5aypcoi3k7p6aipz7nw2hhax77xmai
 default_ledger: ethereum

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeigu4tcjo5pyzrzap6yi54ax6h74bghcrubezkz632f6a4uw6eufja
+agent: dvilela/memeooorr:0.1.0:bafybeiht6cxx5v3oaxdidc5pl2t34nc7tgsfxi4hxiygmfnquk4bn522nu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeicf6zmz2gtj3n7u6qzzmllmyirmimgsazzhyggim7k3ju3twwcqqm
+agent: dvilela/memeooorr:0.1.0:bafybeigu4tcjo5pyzrzap6yi54ax6h74bghcrubezkz632f6a4uw6eufja
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -979,7 +979,7 @@ class MemeooorrBaseBehaviour(
         :param action_type: The type of action, e.g., "tool_action", "tweet_action".
         :param action_data: The dictionary containing the action data to store.
         """
-        current_agent_actions = yield from self._get_stored_kv_data("agent_actions", {})
+        current_agent_actions = yield from self._read_json_from_kv("agent_actions", {})
 
         # Ensure all action types are initialized as lists
         for key in ["tool_action", "tweet_action", "token_action"]:
@@ -1008,7 +1008,7 @@ class MemeooorrBaseBehaviour(
         :param limit: The maximum number of actions to return.
         :return: A list of the latest actions.
         """
-        agent_actions = yield from self._get_stored_kv_data("agent_actions", {})
+        agent_actions = yield from self._read_json_from_kv("agent_actions", {})
         action_list = agent_actions.get(action_type, [])
 
         if not isinstance(action_list, list):
@@ -1020,7 +1020,7 @@ class MemeooorrBaseBehaviour(
         # Return the last 'limit' items
         return action_list[-limit:]
 
-    def _get_stored_kv_data(
+    def _read_json_from_kv(
         self, key: str, default_value: Any
     ) -> Generator[None, None, Any]:
         """Helper to get and parse stored KV data."""

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -989,7 +989,7 @@ class MemeooorrBaseBehaviour(
 
         if not isinstance(action_list, list):
             self.context.logger.warning(
-                f"Expected '{action_type}' to be a list, but found {type(action_list)}. Resetting to empty list."
+                f"Expected {action_type} to be a list, but found {type(action_list)}. Resetting to empty list."
             )
             action_list = []
 
@@ -1013,7 +1013,7 @@ class MemeooorrBaseBehaviour(
 
         if not isinstance(action_list, list):
             self.context.logger.warning(
-                f"Expected '{action_type}' to be a list, but found {type(action_list)}. Resetting to empty list."
+                f"Expected {action_type} to be a list, but found {type(action_list)}. Resetting to empty list."
             )
             return []
 

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/chain.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/chain.py
@@ -683,6 +683,11 @@ class ActionPreparationBehaviour(ChainBehaviour):  # pylint: disable=too-many-an
 
         # Action finished if we already have a final_tx_hash at this point
         if self.synchronized_data.final_tx_hash is not None:
+            # wrting action to the KV store inside agent_actions
+            yield from self._store_agent_action(
+                action_type="token_action",
+                action_data=token_action,
+            )
             yield from self.post_action()
             return ""
 

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -1072,16 +1072,6 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
 
         return mech_summary
 
-    def _get_stored_kv_data(
-        self, key: str, default_value: Any
-    ) -> Generator[None, None, Any]:
-        """Helper to get and parse stored KV data."""
-        data = yield from self._read_kv(keys=(key,))
-        if not data:
-            self.context.logger.error(f"No {key} found in KV store")
-            return default_value
-        return json.loads(data[key])
-
     def _get_llm_decision(self, prompt: str) -> Generator[None, None, Optional[str]]:
         """Get decision from LLM."""
         self.context.logger.info(f"Prompting the LLM for a decision: {prompt}")

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -920,6 +920,10 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             )
             tools_info = (self.generate_mech_tool_info(),)  # type: ignore
 
+        # get the latest actions from the KV store
+        tweet_actions = yield from self.get_latest_agent_actions("tweet_action")
+        tool_actions = yield from self.get_latest_agent_actions("tool_action")
+
         prompt = TWITTER_DECISION_PROMPT.format(
             persona=persona,
             previous_tweets=previous_tweets_str,
@@ -928,6 +932,8 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             tools=tools_info,
             time=self.get_sync_time_str(),
             extra_command=extra_command,
+            tweet_actions=tweet_actions,
+            tool_actions=tool_actions,
         )
 
         # Save data for future mech responses

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -809,9 +809,11 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
                 return Event.ERROR.value, new_interacted_tweet_ids, []
 
             # Handle the tool action normally
-            event, new_interacted_tweet_id, mech_request = self._handle_tool_action(
-                json_response
-            )
+            (
+                event,
+                new_interacted_tweet_id,
+                mech_request,
+            ) = yield from self._handle_tool_action(json_response)
             return event, new_interacted_tweet_id, mech_request
 
         # Handle tweet actions if present

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -1213,6 +1213,8 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             )
         )
 
+        yield from self._store_agent_action("tool_action", tool_name)
+
         return Event.MECH.value, [], new_mech_requests
 
     def _handle_tweet_actions(  # pylint: disable=too-many-arguments
@@ -1270,6 +1272,8 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             action, tweet_id, user_name, context.pending_tweets
         ):
             return
+
+        yield from self._store_agent_action("tweet_action", interaction)
 
         # Add random delay to avoid rate limiting
         delay = secrets.randbelow(5)

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -1180,7 +1180,9 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
 
         return self._validate_non_mech_llm_response(json_response)
 
-    def _handle_tool_action(self, json_response: dict) -> Tuple[str, List, List]:
+    def _handle_tool_action(
+        self, json_response: dict
+    ) -> Generator[None, None, Tuple[str, List, List]]:
         """Handle tool action from LLM response."""
         self.context.logger.info("Tool action detected")
 

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -559,33 +559,19 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
         )
 
         # Fetch pending tweets from db
-        pending_tweets_data = yield from self._read_kv(
-            keys=("pending_tweets_for_tw_mech",)
+        pending_tweets = yield from self._read_json_from_kv(
+            "pending_tweets_for_tw_mech", {}
         )
-        pending_tweets = {}
-        if pending_tweets_data and pending_tweets_data.get(
-            "pending_tweets_for_tw_mech"
-        ):
-            pending_tweets = json.loads(
-                pending_tweets_data["pending_tweets_for_tw_mech"]
-            )
-        else:
+        if not pending_tweets:
             self.context.logger.warning(
                 "No pending tweets found in KV store or value is empty."
             )
 
         # Fetch previously interacted tweets
-        interacted_ids_data = yield from self._read_kv(
-            keys=("interacted_tweet_ids_for_tw_mech",)
+        interacted_tweet_ids = yield from self._read_json_from_kv(
+            "interacted_tweet_ids_for_tw_mech", []
         )
-        interacted_tweet_ids = []
-        if interacted_ids_data and interacted_ids_data.get(
-            "interacted_tweet_ids_for_tw_mech"
-        ):
-            interacted_tweet_ids = json.loads(
-                interacted_ids_data["interacted_tweet_ids_for_tw_mech"]
-            )
-        else:
+        if not interacted_tweet_ids:
             self.context.logger.warning(
                 "No interacted tweets found in KV store or value is empty."
             )
@@ -626,13 +612,7 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
 
     def _get_interacted_tweet_ids(self) -> Generator[None, None, list]:
         """Get previously interacted tweet IDs from the database."""
-        db_data = yield from self._read_kv(keys=("interacted_tweet_ids",))
-
-        if db_data is None:
-            self.context.logger.error("Error while loading the database")
-            return []
-
-        return json.loads(db_data["interacted_tweet_ids"] or "[]")
+        return (yield from self._read_json_from_kv("interacted_tweet_ids", []))
 
     def _collect_pending_tweets(
         self, active_agents: List[AgentsFunAgent], interacted_tweet_ids: set[int]
@@ -732,18 +712,15 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
         json_response = None
 
         # Try to get the previously stored prompt first
-        stored_prompt_data = yield from self._read_kv(keys=("last_prompt",))
-        stored_prompt = (
-            stored_prompt_data.get("last_prompt") if stored_prompt_data else None
-        )
+        stored_prompt = yield from self._read_json_from_kv("last_prompt", None)
 
         # Check if we should use a stored prompt or generate a new one
         if stored_prompt and retry_count > 0:
             self.context.logger.info("Using previously stored prompt")
             prompt = stored_prompt
             # We still need previous_tweets for potential media handling
-            previous_tweets = yield from self._get_stored_kv_data(
-                "previous_tweets_for_tw_mech", {}
+            previous_tweets = yield from self._read_json_from_kv(
+                "previous_tweets_for_tw_mech", []
             )
         else:
             # Generate a new prompt and store it
@@ -910,7 +887,7 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             self.context.logger.info(
                 "It seems like the mech failed to deliver the response forcing agent to create a normal tweet"
             )
-            last_prompt = yield from self._read_kv(keys=("last_prompt",))
+            last_prompt = yield from self._read_json_from_kv("last_prompt", None)
             ENFORCE_ACTION_COMMAND_FAILED_MECH_SUBPROMPT = (
                 ENFORCE_ACTION_COMMAND_FAILED_MECH.format(last_prompt=last_prompt)
             )
@@ -970,17 +947,14 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
     ) -> Generator[None, None, Tuple[str, Optional[List[Dict]]]]:
         """Prepare prompt data when mech_for_twitter is True."""
         # Read saved data for mech response
-        previous_tweets_data = yield from self._get_stored_kv_data(
+        previous_tweets = yield from self._read_json_from_kv(
             "previous_tweets_for_tw_mech", []
         )
-        other_tweets_data = yield from self._get_stored_kv_data(
+        other_tweets_data = yield from self._read_json_from_kv(
             "other_tweets_for_tw_mech", {}
         )
 
         # Ensure previous_tweets is Optional[List[Dict]]
-        previous_tweets = (
-            previous_tweets_data if isinstance(previous_tweets_data, list) else None
-        )
         previous_tweets_str = BaseTweetBehaviour._format_previous_tweets_str(
             previous_tweets
         )
@@ -1037,18 +1011,12 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
     def _get_latest_media_info(self) -> Generator[None, None, Optional[Dict]]:
         """Reads and parses the 'latest_media_info' from the KV store."""
         try:
-            media_info_data = yield from self._read_kv(keys=("latest_media_info",))
-            if (
-                not media_info_data
-                or "latest_media_info" not in media_info_data
-                or not media_info_data["latest_media_info"]
-            ):
+            media_info = yield from self._read_json_from_kv("latest_media_info", None)
+            if not media_info:
                 self.context.logger.warning(
                     "Could not find valid 'latest_media_info' in KV store."
                 )
                 return None
-
-            media_info = json.loads(media_info_data["latest_media_info"])
             return media_info
         except json.JSONDecodeError:
             self.context.logger.error(

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -851,7 +851,7 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
 
         return prompt, previous_tweets
 
-    def _prepare_standard_prompt_data(
+    def _prepare_standard_prompt_data(  # pylint: disable=too-many-locals
         self, pending_tweets: dict, persona: str
     ) -> Generator[None, None, Tuple[str, Optional[List[Dict]]]]:
         """Prepare prompt data when mech_for_twitter is False."""

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/twitter.py
@@ -991,6 +991,8 @@ class EngageTwitterBehaviour(BaseTweetBehaviour):  # pylint: disable=too-many-an
             tools=self.generate_mech_tool_info(),
             time=self.get_sync_time_str(),
             extra_command="",
+            tweet_actions="",
+            tool_actions="",
         )
 
         # Clear stored data

--- a/packages/dvilela/skills/memeooorr_abci/prompts.py
+++ b/packages/dvilela/skills/memeooorr_abci/prompts.py
@@ -71,6 +71,15 @@ You must choose **either** a Twitter action **or** a Tool action, but not both.
 
 {extra_command}
 
+Please do not repeat the same action many times. try to do different actions
+Here are some of your previous:
+
+Tweet actions:
+{tweet_actions}
+
+Tool actions:
+{tool_actions}
+
 Your task is to decide what actions to do, if any. Some recommenadations:
 - Do not invent or assume any details. Use only the information provided. as we do not want to spread misinformation.
 - If you decide to tweet, make sure it is significantly different from previous tweets in both topic and wording.

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,12 +8,12 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeiaejoan3xjiwoqcyfyihd35sgq6hs7lf36qdtrdb57pdnx5i3ozre
+  behaviour_classes/base.py: bafybeidhtokakpjflbpjnvezglmzh4rvqbt44zv3e4dapuwujujacl447e
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
   behaviour_classes/mech.py: bafybeiaqpjmuvki42kmhgelm4kgk2z5o2s3i2xtrttwhyu6273padrma5y
-  behaviour_classes/twitter.py: bafybeicpnwjd3heslolncn43ggafztrjw2wy3rdwyqcwpa724tpdce3dzi
+  behaviour_classes/twitter.py: bafybeigstcuik2wg4vzkjtxmupuhhww6ktbraed4bv6x7z5icee3g3utja
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,19 +8,19 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeibkhb57jnhgx2hnh3yqrlvhx2a4jaotx2ka4htir6dwbxzjybta24
-  behaviour_classes/chain.py: bafybeidvsctiti46qcwrcncodttbm6my2axcm3fu4kzybbew6rasy7qhwa
+  behaviour_classes/base.py: bafybeiaejoan3xjiwoqcyfyihd35sgq6hs7lf36qdtrdb57pdnx5i3ozre
+  behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
   behaviour_classes/mech.py: bafybeiaqpjmuvki42kmhgelm4kgk2z5o2s3i2xtrttwhyu6273padrma5y
-  behaviour_classes/twitter.py: bafybeihzmzf3odhtlwqp5i2ycaudzl5tth6webifp2w65wcstoql5mvtqq
+  behaviour_classes/twitter.py: bafybeicpnwjd3heslolncn43ggafztrjw2wy3rdwyqcwpa724tpdce3dzi
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
   handlers.py: bafybeicdbw4ayfuifdgmyezncazjabr333ltieaxq5gbgh5s7nkp5llxyi
   models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
   payloads.py: bafybeiez63hch4jpzeqd6nxrnvgw4mwbd7fdnru3vmbiw3qpdbr4qfm2uu
-  prompts.py: bafybeifdxpe6ttyxz3yicskmiads7qvcou6533dpuk7dc2sbi7e2prdg3e
+  prompts.py: bafybeib5c6mgdzyjwgqbircmodsh6zityos5relc5wtaglurgdmuqdwmia
   rounds.py: bafybeibcdt7w3jn3mfdurifvn4gfqa3amhg4fufz66kxlh5srjtuxqtame
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm
+- dvilela/memeooorr_abci:0.1.0:bafybeidfuko4vlaaiarivm3b4xbrfvi2wnzamnncmd42j446lrycdeqjeu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeib3n6f7gxnkfe66pabg2hjdfzvrvgzj46jeejcuap7zudtwnbgoza
+- dvilela/memeooorr_abci:0.1.0:bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeih2qydhqx7yiesrfcxnbzc3rg5iyyz4r3ciwswx3wnsxo2oa3p4yy",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidfuko4vlaaiarivm3b4xbrfvi2wnzamnncmd42j446lrycdeqjeu",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihxbnhjepkonb27cmdez3e3na5vypvsyy7sus2ogscih5qj5g5moy",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiflqrbpbevteriivevm2uhu5aypcoi3k7p6aipz7nw2hhax77xmai",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeigu4tcjo5pyzrzap6yi54ax6h74bghcrubezkz632f6a4uw6eufja",
-        "service/dvilela/memeooorr/0.1.0": "bafybeid6csv473gxmmhhlnfhsf5pj75eyb3fsvbdmltujl2xxim4tgiew4"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiht6cxx5v3oaxdidc5pl2t34nc7tgsfxi4hxiygmfnquk4bn522nu",
+        "service/dvilela/memeooorr/0.1.0": "bafybeieeoqbdrq3isjuqedwzqnrygedkprweawadkjwemqv5f5gmbzxxsa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeib3n6f7gxnkfe66pabg2hjdfzvrvgzj46jeejcuap7zudtwnbgoza",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihpv7ks6wh67y4a2drkc3obhzmohplqmp2njzerd4tjaumsvdnnlu",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidvrsrnchteehgbn6txpejxhjvqe7hgulhqjry3up43m5vuolypbm",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeih2qydhqx7yiesrfcxnbzc3rg5iyyz4r3ciwswx3wnsxo2oa3p4yy",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiflqrbpbevteriivevm2uhu5aypcoi3k7p6aipz7nw2hhax77xmai",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeicf6zmz2gtj3n7u6qzzmllmyirmimgsazzhyggim7k3ju3twwcqqm",
-        "service/dvilela/memeooorr/0.1.0": "bafybeicz62bfwinyb7qlp74ieqzoh7sw7ui4wi7xhwbviim6tx3xdj3xma"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeigu4tcjo5pyzrzap6yi54ax6h74bghcrubezkz632f6a4uw6eufja",
+        "service/dvilela/memeooorr/0.1.0": "bafybeid6csv473gxmmhhlnfhsf5pj75eyb3fsvbdmltujl2xxim4tgiew4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",


### PR DESCRIPTION
This PR contains some changes to encourage the LLM to diversify is types of tweet and tool action :

1. Added a new Key into local db to store all the agent's actions (tool,tooken,tweet)
2. it will store the latest 10 action of each action type
3. we provide the LLM with tool and tweet action list of last 5 actions and tell it to use different actions
4. added 2 new functions to getter and setter for agent_actions to keep things maintainable
5. moved another fn _get_stored_kv_data from twitter.py to base.py which validates the data read from KV (i could have modified read_kv , but since it is a low level generic fn i didn't want to touch it and _get_stored_kv_data deals specifically with JSON encoded data)
6. we are currently only storing token_actions but not providing it to LLM as it could have unintended effects on game (pls LMK if you think otherwise)
7. kept the token_actions for future use cases such as agent's UI..etc.
