### PR TITLE
stage 1 : added agent details property to sync db

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeic5aooeymxdzvfbniicx7rz55g3sida4vwlkxabwsvvqb2qrakaci
+- dvilela/memeooorr_abci:0.1.0:bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeie54dzdkxreyd3qu3pl65m6mfnc62yrsoky2xdtpyl7ikqfrey4mi
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,7 +13,7 @@ connections:
 - valory/http_client:0.23.0:bafybeid5ffvg76ejjoese7brj5ji3lx66cu7p2ixfwflpo6rgofkypfd7y
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
-- dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
+- dvilela/tweepy:0.1.0:bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64
 - dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeiclkfjfkvzceojcgyzezhbi6qaao6qtnzsayscxv4xwmnsdtzggga
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeihbzj2cyul6p5qt7cnev5pfwrwdee7b6nhwiptktjrhszigguhwji
+- dvilela/memeooorr_abci:0.1.0:bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeic5aooeymxdzvfbniicx7rz55g3sida4vwlkxabwsvvqb2qrakaci
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/connections/tweepy/connection.yaml
+++ b/packages/dvilela/connections/tweepy/connection.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeicrwqrdownfmeyvvzu45fllxouiwvtynrzs5fhbpt3wndyyhn66eu
   connection.py: bafybeienxlo7bkj57niiotqm3zo4sagioygdwk3ewlmzgozpi7bte6sucm
   readme.md: bafybeib5oflnp3gymrottersu6qrnitjmaifl2gvbvjq7kbmsdbihhzfaa
-  tweepy_wrapper.py: bafybeiduf2ogkjxvzw7hnuf3googhnuk2hdwvxhnc7cqiq7zfkkzte3sda
+  tweepy_wrapper.py: bafybeigu44otg6tqxbescqex24wy6islrzavckcn7a33e5wwj2sulij45m
 fingerprint_ignore_patterns: []
 connections: []
 protocols:

--- a/packages/dvilela/connections/tweepy/tweepy_wrapper.py
+++ b/packages/dvilela/connections/tweepy/tweepy_wrapper.py
@@ -218,7 +218,6 @@ class Twitter:
             return {
                 "user_id": result.data.id,
                 "username": result.data.username,
-                "name": result.data.name,
             }
         except tweepy.errors.TweepyException as e:
             self.logger.error(

--- a/packages/dvilela/connections/tweepy/tweepy_wrapper.py
+++ b/packages/dvilela/connections/tweepy/tweepy_wrapper.py
@@ -215,7 +215,11 @@ class Twitter:
         """Get my user."""
         try:
             result = self.client.get_me()
-            return {"user_id": result.data.id, "username": result.data.username}
+            return {
+                "user_id": result.data.id,
+                "username": result.data.username,
+                "name": result.data.name,
+            }
         except tweepy.errors.TweepyException as e:
             self.logger.error(
                 f"TweepyException in method get_me: {type(e).__name__} - {e}"

--- a/packages/dvilela/connections/tweepy/tweepy_wrapper.py
+++ b/packages/dvilela/connections/tweepy/tweepy_wrapper.py
@@ -215,7 +215,11 @@ class Twitter:
         """Get my user."""
         try:
             result = self.client.get_me()
-            return {"user_id": result.data.id, "username": result.data.username}
+            return {
+                "user_id": result.data.id,
+                "username": result.data.username,
+                "display_name": result.data.name,
+            }
         except tweepy.errors.TweepyException as e:
             self.logger.error(
                 f"TweepyException in method get_me: {type(e).__name__} - {e}"

--- a/packages/dvilela/connections/tweepy/tweepy_wrapper.py
+++ b/packages/dvilela/connections/tweepy/tweepy_wrapper.py
@@ -215,10 +215,7 @@ class Twitter:
         """Get my user."""
         try:
             result = self.client.get_me()
-            return {
-                "user_id": result.data.id,
-                "username": result.data.username,
-            }
+            return {"user_id": result.data.id, "username": result.data.username}
         except tweepy.errors.TweepyException as e:
             self.logger.error(
                 f"TweepyException in method get_me: {type(e).__name__} - {e}"

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeiamyf4lesy6gk6u4oyo2m7wmjrl3nmvsp73fbsp56q7m2pdpvph34
+agent: dvilela/memeooorr:0.1.0:bafybeicfjprkqmsr5so24k5j3yjfjqhrb7lcfb72p3556sqkzgp23yccnq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeibwt5kqnsetvo7wolsnon6lhelqoidfx24rvt6qy2omvyxf3eri3u
+agent: dvilela/memeooorr:0.1.0:bafybeiamyf4lesy6gk6u4oyo2m7wmjrl3nmvsp73fbsp56q7m2pdpvph34
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -957,6 +957,7 @@ class MemeooorrBaseBehaviour(
             return
         self.context.state.twitter_username = account_details.get("username")
         self.context.state.twitter_id = account_details.get("user_id")
+        self.context.state.twitter_display_name = account_details.get("display_name")
 
         self.context.agents_fun_db.my_agent.twitter_username = (
             self.context.state.twitter_username

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/db.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/db.py
@@ -19,6 +19,7 @@
 
 """This package contains round behaviours of MemeooorrAbciApp."""
 
+import json
 from typing import Generator, Type
 
 from packages.dvilela.skills.memeooorr_abci.behaviour_classes.base import (
@@ -45,10 +46,12 @@ class LoadDatabaseBehaviour(
             persona = yield from self.load_db()
             yield from self.populate_keys_in_kv()
             yield from self.init_own_twitter_details()
+            agent_details = self.gather_agent_details(persona)
 
             payload = LoadDatabasePayload(
                 sender=self.context.agent_address,
                 persona=persona,
+                agent_details=agent_details,
             )
 
         with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
@@ -77,3 +80,15 @@ class LoadDatabaseBehaviour(
             yield from self._write_kv(
                 {"last_summon_timestamp": str(self.get_sync_timestamp())}
             )
+
+    def gather_agent_details(self, persona: str) -> Generator[None, None, str]:
+        """Write the agent details to the db."""
+        agent_details = {
+            "twitter_username": self.context.agents_fun_db.my_agent.twitter_username,
+            "twitter_user_id": self.context.agents_fun_db.my_agent.twitter_user_id,
+            "safe_address": self.synchronized_data.safe_contract_address,
+            "persona": persona,
+            "twitter_display_name": self.context.state.twitter_display_name,
+        }
+        agent_details_str = json.dumps(agent_details)
+        return agent_details_str

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/db.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/db.py
@@ -81,7 +81,7 @@ class LoadDatabaseBehaviour(
                 {"last_summon_timestamp": str(self.get_sync_timestamp())}
             )
 
-    def gather_agent_details(self, persona: str) -> Generator[None, None, str]:
+    def gather_agent_details(self, persona: str) -> str:
         """Write the agent details to the db."""
         agent_details = {
             "twitter_username": self.context.agents_fun_db.my_agent.twitter_username,

--- a/packages/dvilela/skills/memeooorr_abci/payloads.py
+++ b/packages/dvilela/skills/memeooorr_abci/payloads.py
@@ -30,6 +30,7 @@ class LoadDatabasePayload(BaseTxPayload):
     """Represent a transaction payload for the LoadDatabaseRound."""
 
     persona: str
+    agent_details: str
 
 
 @dataclass(frozen=True)

--- a/packages/dvilela/skills/memeooorr_abci/rounds.py
+++ b/packages/dvilela/skills/memeooorr_abci/rounds.py
@@ -199,6 +199,12 @@ class SynchronizedData(BaseSynchronizedData):
         """Get the check funds count."""
         return int(self.db.get("check_funds_count", 0))  # type: ignore
 
+    @property
+    def agent_details(self) -> Dict[str, Any]:
+        """Get the agent details."""
+        serialized_details = self.db.get("agent_details", "{}")
+        return json.loads(serialized_details)
+
 
 class EventRoundBase(CollectSameUntilThresholdRound):
     """EventRoundBase"""
@@ -245,12 +251,15 @@ class LoadDatabaseRound(CollectSameUntilThresholdRound):
         # Event.DONE, Event.NO_MAJORITY, Event.ROUND_TIMEOUT
 
         if self.threshold_reached:
-            payload = dict(zip(self.selection_key, self.most_voted_payload_values))
+            payload = LoadDatabasePayload(
+                *(("dummy_sender",) + self.most_voted_payload_values)
+            )
 
             synchronized_data = self.synchronized_data.update(
                 synchronized_data_class=SynchronizedData,
                 **{
-                    get_name(SynchronizedData.persona): payload["persona"],
+                    get_name(SynchronizedData.persona): payload.persona,
+                    get_name(SynchronizedData.agent_details): payload.agent_details,
                 },
             )
 

--- a/packages/dvilela/skills/memeooorr_abci/rounds.py
+++ b/packages/dvilela/skills/memeooorr_abci/rounds.py
@@ -202,7 +202,7 @@ class SynchronizedData(BaseSynchronizedData):
     @property
     def agent_details(self) -> Dict[str, Any]:
         """Get the agent details."""
-        serialized_details = self.db.get("agent_details", "{}")
+        serialized_details = cast(str, self.db.get("agent_details", "{}"))
         return json.loads(serialized_details)
 
 

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -10,7 +10,7 @@ fingerprint:
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
   behaviour_classes/base.py: bafybeib5e4c5sozoiwpoenbr3j26fmlvlzgym5byl4wfegwrejdynznmzq
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
-  behaviour_classes/db.py: bafybeia4chvi2gbtrpr6czrj624sdzsenyh3x5pycom7jqsa5s5nbyn534
+  behaviour_classes/db.py: bafybeiem7ik2a3jxvqpwujkpead5vjjf2rwxhptacwmebwzibhvgczlg5e
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
   behaviour_classes/mech.py: bafybeiaqpjmuvki42kmhgelm4kgk2z5o2s3i2xtrttwhyu6273padrma5y
   behaviour_classes/twitter.py: bafybeifgujif3cg4iflgkkt5w7y2db4gya4xjz3c7hdqrhjycgh7bs2ple
@@ -21,7 +21,7 @@ fingerprint:
   models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
   payloads.py: bafybeibkyns7pplvrfcimq4umyufvvk6of4pbqqkqzmxpqwbwmmshcf6xe
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky
-  rounds.py: bafybeib2cogtyumou6z7ul3t53oh2f74dc63vwz5mjyry3274rxjxwpxwm
+  rounds.py: bafybeidqbu2vzfvgozi7ey24iyj2hubrvzjak6udh4gr2udlvfvggozjcu
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,9 +8,9 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeidhtokakpjflbpjnvezglmzh4rvqbt44zv3e4dapuwujujacl447e
+  behaviour_classes/base.py: bafybeib5e4c5sozoiwpoenbr3j26fmlvlzgym5byl4wfegwrejdynznmzq
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
-  behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
+  behaviour_classes/db.py: bafybeia4chvi2gbtrpr6czrj624sdzsenyh3x5pycom7jqsa5s5nbyn534
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
   behaviour_classes/mech.py: bafybeiaqpjmuvki42kmhgelm4kgk2z5o2s3i2xtrttwhyu6273padrma5y
   behaviour_classes/twitter.py: bafybeifgujif3cg4iflgkkt5w7y2db4gya4xjz3c7hdqrhjycgh7bs2ple
@@ -19,14 +19,14 @@ fingerprint:
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
   handlers.py: bafybeicdbw4ayfuifdgmyezncazjabr333ltieaxq5gbgh5s7nkp5llxyi
   models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
-  payloads.py: bafybeiez63hch4jpzeqd6nxrnvgw4mwbd7fdnru3vmbiw3qpdbr4qfm2uu
+  payloads.py: bafybeibkyns7pplvrfcimq4umyufvvk6of4pbqqkqzmxpqwbwmmshcf6xe
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky
-  rounds.py: bafybeibcdt7w3jn3mfdurifvn4gfqa3amhg4fufz66kxlh5srjtuxqtame
+  rounds.py: bafybeib2cogtyumou6z7ul3t53oh2f74dc63vwz5mjyry3274rxjxwpxwm
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
-- dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
+- dvilela/tweepy:0.1.0:bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 contracts:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeiclkfjfkvzceojcgyzezhbi6qaao6qtnzsayscxv4xwmnsdtzggga
+- dvilela/memeooorr_abci:0.1.0:bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha
+- dvilela/memeooorr_abci:0.1.0:bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
-        "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiclkfjfkvzceojcgyzezhbi6qaao6qtnzsayscxv4xwmnsdtzggga",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihbzj2cyul6p5qt7cnev5pfwrwdee7b6nhwiptktjrhszigguhwji",
+        "connection/dvilela/tweepy/0.1.0": "bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeic5aooeymxdzvfbniicx7rz55g3sida4vwlkxabwsvvqb2qrakaci",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeibwt5kqnsetvo7wolsnon6lhelqoidfx24rvt6qy2omvyxf3eri3u",
-        "service/dvilela/memeooorr/0.1.0": "bafybeia5jxti7aibz2ebtfgbpoqmdq5hetmytk2z6eucq2enf7hm6wentq"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeiamyf4lesy6gk6u4oyo2m7wmjrl3nmvsp73fbsp56q7m2pdpvph34",
+        "service/dvilela/memeooorr/0.1.0": "bafybeicwhlx7u2omgta2ialeisqjakmpyhu57ofi54dgsfbfkxk2hyorfa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeievjg3bxa7pkz2inpa6atepmyplhcvjwkf5q6mfb4mys3yvt4q7ha",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeic5aooeymxdzvfbniicx7rz55g3sida4vwlkxabwsvvqb2qrakaci",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeie54dzdkxreyd3qu3pl65m6mfnc62yrsoky2xdtpyl7ikqfrey4mi",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeiamyf4lesy6gk6u4oyo2m7wmjrl3nmvsp73fbsp56q7m2pdpvph34",
-        "service/dvilela/memeooorr/0.1.0": "bafybeicwhlx7u2omgta2ialeisqjakmpyhu57ofi54dgsfbfkxk2hyorfa"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeicfjprkqmsr5so24k5j3yjfjqhrb7lcfb72p3556sqkzgp23yccnq",
+        "service/dvilela/memeooorr/0.1.0": "bafybeigmlpllqze6x6txtqfoqxcg3xw6dlzxmrduaa7cz2ludto2ilxlnm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",


### PR DESCRIPTION
This PR includes changes to store the agent_details in the syncDB , 

This include the partial changes , which will be easier for us to track

###  tweepy_wrapper.py

1. updated get_me fn to return display name

### payloads.py

1. updated loaddatabsePayload to include agent_details

### db.py

1. added a new function to gather all the details for the endpoints which exposes the agent details
2. updated the async_act fn to include agent details in the payload

### base.py

1. updated init_own_twitter_details to store the twitter_display_name in state , so we can use it in loaddbround

### rounds.py

1. updated the property agent_details after getting agent_details from payload 

