### PR TITLE
Stage 2 : included http handler for returning agents-info

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeie54dzdkxreyd3qu3pl65m6mfnc62yrsoky2xdtpyl7ikqfrey4mi
+- dvilela/memeooorr_abci:0.1.0:bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeifwfc7jev5556xoerulk6nyxijzq7o4t4grxu3czwwicboti6wdna
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeicfjprkqmsr5so24k5j3yjfjqhrb7lcfb72p3556sqkzgp23yccnq
+agent: dvilela/memeooorr:0.1.0:bafybeifpgso5dtosq5pb34fhjbihidstekdc77ijtbybsvnb3azqjamany
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/handlers.py
+++ b/packages/dvilela/skills/memeooorr_abci/handlers.py
@@ -151,11 +151,15 @@ class HttpHandler(BaseHttpHandler):
             rf"{hostname_regex}\/.*"
         )
         health_url_regex = rf"{hostname_regex}\/healthcheck"
+        agent_details_url_regex = rf"{hostname_regex}\/agent-info"
 
         # Routes
         self.routes = {  # pylint: disable=attribute-defined-outside-init
             (HttpMethod.GET.value, HttpMethod.HEAD.value): [
                 (health_url_regex, self._handle_get_health)
+            ],
+            (HttpMethod.GET.value, HttpMethod.HEAD.value): [
+                (agent_details_url_regex, self._handle_get_agent_details)
             ],
         }
 
@@ -344,6 +348,20 @@ class HttpHandler(BaseHttpHandler):
             "is_transitioning_fast": is_transitioning_fast,
             "rounds_info": self.rounds_info,
             "env_var_status": self.context.state.env_var_status,
+        }
+
+        self._send_ok_response(http_msg, http_dialogue, data)
+
+    def _handle_get_agent_details(
+        self, http_msg: HttpMessage, http_dialogue: HttpDialogue
+    ) -> None:
+        """Handle a Http request of verb GET."""
+        agent_details = self.synchronized_data.agent_details
+        data = {
+            "address": agent_details.get("safe_address"),
+            "username": agent_details.get("twitter_username"),
+            "name": agent_details.get("twitter_display_name"),
+            "personaDescription": agent_details.get("persona"),
         }
 
         self._send_ok_response(http_msg, http_dialogue, data)

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -17,7 +17,7 @@ fingerprint:
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
-  handlers.py: bafybeicdbw4ayfuifdgmyezncazjabr333ltieaxq5gbgh5s7nkp5llxyi
+  handlers.py: bafybeifbxtnrc4775q2asgh2nnbidfgalzkqscozirbtwtii2dkqtwxivu
   models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
   payloads.py: bafybeibkyns7pplvrfcimq4umyufvvk6of4pbqqkqzmxpqwbwmmshcf6xe
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi
+- dvilela/memeooorr_abci:0.1.0:bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeiabmqurcmyqmspzp2cghgr2kkos2cjkhniz3uqjuukccmuupljeqi",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeie54dzdkxreyd3qu3pl65m6mfnc62yrsoky2xdtpyl7ikqfrey4mi",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifwfc7jev5556xoerulk6nyxijzq7o4t4grxu3czwwicboti6wdna",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeicfjprkqmsr5so24k5j3yjfjqhrb7lcfb72p3556sqkzgp23yccnq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeigmlpllqze6x6txtqfoqxcg3xw6dlzxmrduaa7cz2ludto2ilxlnm"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeifpgso5dtosq5pb34fhjbihidstekdc77ijtbybsvnb3azqjamany",
+        "service/dvilela/memeooorr/0.1.0": "bafybeihyyn6mgevxuzklnu4de3nic7pbep5yyox2zepjnbilddqgsompw4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",


### PR DESCRIPTION
This PR should only be reviewed once this [PR](https://github.com/dvilelaf/meme-ooorr/pull/244) has been merged

This PR includes the http handlers for the agent-infot endpoint 

1. created a fn _handle_get_agent_details which taked agent info from sync db 
2. added a new route according to the doc