### PR TITLE
Media storage location change 

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeihny7wrzbq4vfbs554smao535x56b6fophk3lnyyffu4d5jzu6l3u
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeiew22psienxebh5ueym26f4v75aon6mwex4wmcxrep7e6l623xozi
+- dvilela/memeooorr_abci:0.1.0:bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeif7hz4iej5sl7ov5k2vi2a5mnfq7af6zondqoqmhp4nwee6mm734a
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -14,7 +14,7 @@ connections:
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - dvilela/tweepy:0.1.0:bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64
-- dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
+- dvilela/kv_store:0.1.0:bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 contracts:
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeifwfc7jev5556xoerulk6nyxijzq7o4t4grxu3czwwicboti6wdna
+- dvilela/memeooorr_abci:0.1.0:bafybeigpu6b2htwgbotkgaryzpxwxynxp2od6o3w7trngq6v3txfjv2nhq
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeihlzkqf33rew2mat5ocifehlif5m74kljdi4vu47z2ywokmvynjhe
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeif7hz4iej5sl7ov5k2vi2a5mnfq7af6zondqoqmhp4nwee6mm734a
+- dvilela/memeooorr_abci:0.1.0:bafybeihrp54srw3of5wumcwlrhhyqmwokghqofngjno5bazczvygeksjrq
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeib6vcysse7zqnnxs3yjfoyttui3twtywdzyagcyfslszpdxwtplb4
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -14,7 +14,7 @@ connections:
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
-- dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
+- dvilela/kv_store:0.1.0:bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 contracts:
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeicngn7kmubrluce4djvtyw6c4kbgedzbwkjqln4t5fyp7y7amzynm
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeidjvx2pyx5xlqdya6i7t2nfesowxtypqcf4i7naacs72nuy4ugnbu
+- dvilela/memeooorr_abci:0.1.0:bafybeihny7wrzbq4vfbs554smao535x56b6fophk3lnyyffu4d5jzu6l3u
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeiew22psienxebh5ueym26f4v75aon6mwex4wmcxrep7e6l623xozi
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy
 default_ledger: ethereum
@@ -219,6 +219,7 @@ models:
       olas_token_address_base: ${str:0x54330d28ca3357F294334BDC454a032e7f353416}
       olas_token_address_celo: ${str:0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51}
       persona: ${str:a cat lover that is crazy about all-things cats.}
+      store_path: ${str:/data}
       home_chain_id: ${str:BASE}
       service_registry_address_base: ${str:0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE}
       service_registry_address_celo: ${str:0xE3607b00E75f6405248323A9417ff6b39B244b50}

--- a/packages/dvilela/connections/kv_store/connection.py
+++ b/packages/dvilela/connections/kv_store/connection.py
@@ -98,7 +98,7 @@ class KvStoreConnection(BaseSyncConnection):
         super().__init__(*args, **kwargs)
         self.dialogues = KvStoreDialogues(connection_id=PUBLIC_ID)
 
-        store_path = Path(self.configuration.config.get("store_path", "/tmp"))  # nosec
+        store_path = Path(self.configuration.config.get("store_path", "/data"))  # nosec
 
         if not store_path.exists():
             store_path.mkdir(parents=True, exist_ok=True)

--- a/packages/dvilela/connections/kv_store/connection.yaml
+++ b/packages/dvilela/connections/kv_store/connection.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeig2uzkwmyfyqip5uhswjbxm3r5qlunn4m32kmgi24w3imiotecrmi
-  connection.py: bafybeicqpb6ityaadvtmz6iiwbmrzwweba7dhh4spnlq6grwudfqbpxgny
+  connection.py: bafybeigeulkt3wny7cwukwmxvjd3ak7bfyeov6fug2zsjewueeou5pypzy
   readme.md: bafybeigyb5o5tymr2cl6mgdf2mcb74v66iuc4m4rwvxox5wtydsqxy7dmm
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeiareeumacotysbvo66rlwx6tvbacw3h3swuefwzqep6lkfcbm57uq
+agent: dvilela/memeooorr:0.1.0:bafybeihq4z2kuxfwi26kgmq4imfcgho3itfcsy6vyyl447g2cscdzm4azu
 number_of_agents: 1
 deployment:
   agent:
@@ -93,6 +93,7 @@ extra:
         olas_token_address_base: ${OLAS_TOKEN_ADDRESS_BASE:str:0x54330d28ca3357F294334BDC454a032e7f353416}
         olas_token_address_celo: ${OLAS_TOKEN_ADDRESS_CELO:str:0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51}
         persona: ${PERSONA:str:a cat lover that is crazy about all-things cats.}
+        store_path: ${STORE_PATH:str:/data}
         home_chain_id: ${HOME_CHAIN_ID:str:BASE}
         service_registry_address_base: ${SERVICE_REGISTRY_ADDRESS_BASE:str:0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE}
         service_registry_address_celo: ${SERVICE_REGISTRY_ADDRESS_CELO:str:0xE3607b00E75f6405248323A9417ff6b39B244b50}

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeid3zhasaijvzahhwc5bm6zyox4zvvpsrtvqjynxysji3shovsxk2a
+agent: dvilela/memeooorr:0.1.0:bafybeif7q5jq5qoknk547fbbz3o4tnfdnxjsr4iszvimlrylw5fchhjqvy
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeihq4z2kuxfwi26kgmq4imfcgho3itfcsy6vyyl447g2cscdzm4azu
+agent: dvilela/memeooorr:0.1.0:bafybeid3zhasaijvzahhwc5bm6zyox4zvvpsrtvqjynxysji3shovsxk2a
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeif7q5jq5qoknk547fbbz3o4tnfdnxjsr4iszvimlrylw5fchhjqvy
+agent: dvilela/memeooorr:0.1.0:bafybeigfwnhjtf5rf5urgmafsgejd4acofqag52sqrvh4wazbp5fxwbj3q
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -20,11 +20,11 @@
 """This package contains round behaviours of MemeooorrAbciApp."""
 
 import json
-from pathlib import Path
 import re
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple, cast
 
 from aea.protocols.base import Message

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -1042,7 +1042,7 @@ class MemeooorrBaseBehaviour(
 
     def _store_media_info_list(self, media_info: Dict) -> Generator[None, None, None]:
         """Store media info in the key-value store"""
-        media_store_list = yield from self._read_json_from_kv("media-store-list", [])
+        media_store_list = yield from self._read_media_info_list()
         media_store_list.append(media_info)
 
         # Enforce retention policy: keep only the latest 20 media files
@@ -1058,6 +1058,11 @@ class MemeooorrBaseBehaviour(
             media_store_list = media_store_list[num_to_remove:]
 
         yield from self._write_kv({"media-store-list": json.dumps(media_store_list)})
+
+    def _read_media_info_list(self) -> Generator[None, None, List[Dict]]:
+        """Read media info from the key-value store"""
+        media_store_list = yield from self._read_json_from_kv("media-store-list", [])
+        return media_store_list
 
     def _cleanup_temp_file(self, file_path: Optional[str], reason: str) -> None:
         """Attempt to remove a temporary file and log the outcome."""

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -1060,9 +1060,7 @@ class MemeooorrBaseBehaviour(
         yield from self._write_kv({"media-store-list": json.dumps(media_store_list)})
 
     def _read_media_info_list(self) -> Generator[None, None, List[Dict]]:
-        """
-        Read media info from the key-value store.
-        """
+        """Read media info from the key-value store"""
         raw_list = yield from self._read_json_from_kv("media-store-list", [])
 
         if not isinstance(raw_list, list):

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/mech.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/mech.py
@@ -20,7 +20,6 @@
 """This package contains round behaviours of MemeooorrAbciApp."""
 import json
 import os
-import tempfile
 import traceback
 from datetime import datetime
 from typing import Generator, List, Optional, Type

--- a/packages/dvilela/skills/memeooorr_abci/models.py
+++ b/packages/dvilela/skills/memeooorr_abci/models.py
@@ -184,5 +184,6 @@ class Params(MechParams):  # pylint: disable=too-many-instance-attributes
         self.summon_cooldown_seconds = self._ensure(
             "summon_cooldown_seconds", kwargs, int
         )
+        self.store_path = self._ensure("store_path", kwargs, str)
 
         super().__init__(*args, **kwargs)

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeidginxb4vf7tw33xozq66tnpjrayfahwa5ox2fdsz2f7mk3xmzfze
+  behaviour_classes/base.py: bafybeianl7bst27pouwbpegeexasmdbbgkmaqkugee6b754lv7r2nldwfi
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiem7ik2a3jxvqpwujkpead5vjjf2rwxhptacwmebwzibhvgczlg5e
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
@@ -18,14 +18,14 @@ fingerprint:
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
   handlers.py: bafybeifbxtnrc4775q2asgh2nnbidfgalzkqscozirbtwtii2dkqtwxivu
-  models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
+  models.py: bafybeiaocuchblmjnp3k5fp372pejigfekicylyxxiffplkqbhao27pltm
   payloads.py: bafybeibkyns7pplvrfcimq4umyufvvk6of4pbqqkqzmxpqwbwmmshcf6xe
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky
   rounds.py: bafybeidqbu2vzfvgozi7ey24iyj2hubrvzjak6udh4gr2udlvfvggozjcu
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []
 connections:
-- dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
+- dvilela/kv_store:0.1.0:bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi
 - dvilela/tweepy:0.1.0:bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeidakxlwr66mjkgnovskrsing23yiard3yj2g4rkcbxfrtyyrwldda
+  behaviour_classes/base.py: bafybeidginxb4vf7tw33xozq66tnpjrayfahwa5ox2fdsz2f7mk3xmzfze
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -12,20 +12,20 @@ fingerprint:
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
-  behaviour_classes/mech.py: bafybeiaqpjmuvki42kmhgelm4kgk2z5o2s3i2xtrttwhyu6273padrma5y
+  behaviour_classes/mech.py: bafybeidfozrpirksdpmf4uu47p2uqa253d2blof7vy4hk4kv2ph4vdllfm
   behaviour_classes/twitter.py: bafybeihanw5wpcegrhrnaff3tpaffyh6sgby3exroreaywohloxd3oi2nm
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
   handlers.py: bafybeicdbw4ayfuifdgmyezncazjabr333ltieaxq5gbgh5s7nkp5llxyi
-  models.py: bafybeidhxnp3vnezsapopaeqgwnvdgw7caabwmhnu4s4up2jhvthezkci4
+  models.py: bafybeiaocuchblmjnp3k5fp372pejigfekicylyxxiffplkqbhao27pltm
   payloads.py: bafybeiez63hch4jpzeqd6nxrnvgw4mwbd7fdnru3vmbiw3qpdbr4qfm2uu
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky
-  rounds.py: bafybeibcdt7w3jn3mfdurifvn4gfqa3amhg4fufz66kxlh5srjtuxqtame
+  rounds.py: bafybeidx6aot7wltci56wtkaew6te5nz5zw6rtrxqcijkz74e4syeydida
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []
 connections:
-- dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
+- dvilela/kv_store:0.1.0:bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi
 - dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
@@ -164,6 +164,7 @@ models:
       olas_token_address_base: '0x54330d28ca3357F294334BDC454a032e7f353416'
       olas_token_address_celo: '0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51'
       persona: a cat lover that is crazy about all-things cats.
+      store_path: /data
       home_chain_id: BASE
       service_registry_address_base: '0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE'
       service_registry_address_celo: '0xE3607b00E75f6405248323A9417ff6b39B244b50'

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,11 +8,11 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeifiq2czlhp3pzldgoulsu2ys2maqztsjzwm4l4is3ltfp3jyf5hgm
+  behaviour_classes/base.py: bafybeidakxlwr66mjkgnovskrsing23yiard3yj2g4rkcbxfrtyyrwldda
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeiftxdcytgujoneieqhlfv5udjcrc4uyreeic662z5lmhwuskimxam
   behaviour_classes/llm.py: bafybeiaxj6ps53froyqtlogfd3y3z3wbiurhoharuft5xuhkzoxtruukya
-  behaviour_classes/mech.py: bafybeidfozrpirksdpmf4uu47p2uqa253d2blof7vy4hk4kv2ph4vdllfm
+  behaviour_classes/mech.py: bafybeiahlqunxnzpci5hjda5dulxjohnqm3lrox3quu2rmupda7tujyodi
   behaviour_classes/twitter.py: bafybeihanw5wpcegrhrnaff3tpaffyh6sgby3exroreaywohloxd3oi2nm
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
@@ -21,7 +21,7 @@ fingerprint:
   models.py: bafybeiaocuchblmjnp3k5fp372pejigfekicylyxxiffplkqbhao27pltm
   payloads.py: bafybeiez63hch4jpzeqd6nxrnvgw4mwbd7fdnru3vmbiw3qpdbr4qfm2uu
   prompts.py: bafybeihbz456kigtnmlmjsraykxkjnnrgmhgpksfgrphm7nqi2a6fkqvky
-  rounds.py: bafybeidx6aot7wltci56wtkaew6te5nz5zw6rtrxqcijkz74e4syeydida
+  rounds.py: bafybeibcdt7w3jn3mfdurifvn4gfqa3amhg4fufz66kxlh5srjtuxqtame
   rounds_info.py: bafybeib6a5a7bvwvfiscnbhsc6sejloelyglnu6lwbeeileyxrsgkxcb6a
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeicngn7kmubrluce4djvtyw6c4kbgedzbwkjqln4t5fyp7y7amzynm
+- dvilela/memeooorr_abci:0.1.0:bafybeihny7wrzbq4vfbs554smao535x56b6fophk3lnyyffu4d5jzu6l3u
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:
@@ -151,6 +151,7 @@ models:
       olas_token_address_base: '0x54330d28ca3357F294334BDC454a032e7f353416'
       olas_token_address_celo: '0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51'
       persona: a cat lover that is crazy about all-things cats.
+      store_path: /data
       home_chain_id: BASE
       service_registry_address_base: '0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE'
       service_registry_address_celo: '0xE3607b00E75f6405248323A9417ff6b39B244b50'

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4
+- dvilela/memeooorr_abci:0.1.0:bafybeihrp54srw3of5wumcwlrhhyqmwokghqofngjno5bazczvygeksjrq
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeihny7wrzbq4vfbs554smao535x56b6fophk3lnyyffu4d5jzu6l3u
+- dvilela/memeooorr_abci:0.1.0:bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia
+- dvilela/memeooorr_abci:0.1.0:bafybeigpu6b2htwgbotkgaryzpxwxynxp2od6o3w7trngq6v3txfjv2nhq
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,13 +7,13 @@
         "connection/dvilela/twikit/0.1.0": "bafybeie7on3y3yzdwivz5wnsp64xq3ak3mn2hcgpw74q4hcop2tw7pur4e",
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
-        "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
+        "connection/dvilela/kv_store/0.1.0": "bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeicngn7kmubrluce4djvtyw6c4kbgedzbwkjqln4t5fyp7y7amzynm",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeidjvx2pyx5xlqdya6i7t2nfesowxtypqcf4i7naacs72nuy4ugnbu",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeif7hz4iej5sl7ov5k2vi2a5mnfq7af6zondqoqmhp4nwee6mm734a",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeiareeumacotysbvo66rlwx6tvbacw3h3swuefwzqep6lkfcbm57uq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeifgpjs7lmbcbki53ajsrao6pyilar6wiaqgudl5incftuhimvtcn4"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeid3zhasaijvzahhwc5bm6zyox4zvvpsrtvqjynxysji3shovsxk2a",
+        "service/dvilela/memeooorr/0.1.0": "bafybeieuzhnd6px2wzptj7ffggr42szu6ztgj7na6kgcfwnhoihunlxf4m"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeig4bmzjqaaqdvizco7yhypy66cjb6zsftw3yknyiphoblnelcxvy4",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeif7hz4iej5sl7ov5k2vi2a5mnfq7af6zondqoqmhp4nwee6mm734a",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeihrp54srw3of5wumcwlrhhyqmwokghqofngjno5bazczvygeksjrq",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeib6vcysse7zqnnxs3yjfoyttui3twtywdzyagcyfslszpdxwtplb4",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeid3zhasaijvzahhwc5bm6zyox4zvvpsrtvqjynxysji3shovsxk2a",
-        "service/dvilela/memeooorr/0.1.0": "bafybeieuzhnd6px2wzptj7ffggr42szu6ztgj7na6kgcfwnhoihunlxf4m"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeif7q5jq5qoknk547fbbz3o4tnfdnxjsr4iszvimlrylw5fchhjqvy",
+        "service/dvilela/memeooorr/0.1.0": "bafybeib2clith5rjl4dvmhf3rw2nbcu545xdmvj37dhp6a4l2towrrmyly"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,13 +7,13 @@
         "connection/dvilela/twikit/0.1.0": "bafybeie7on3y3yzdwivz5wnsp64xq3ak3mn2hcgpw74q4hcop2tw7pur4e",
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
-        "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
+        "connection/dvilela/kv_store/0.1.0": "bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi",
         "connection/dvilela/tweepy/0.1.0": "bafybeibuaj2odbn666yvbuzfg4nmzpm2abptnxa2jnbkryhbdx5vla6b64",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeig53z4acqnoonvo23bo5xzzap7nxzlmfvlpt43c4t34rkjt7isgia",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifwfc7jev5556xoerulk6nyxijzq7o4t4grxu3czwwicboti6wdna",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeigpu6b2htwgbotkgaryzpxwxynxp2od6o3w7trngq6v3txfjv2nhq",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeihlzkqf33rew2mat5ocifehlif5m74kljdi4vu47z2ywokmvynjhe",
         "skill/valory/agent_db_abci/0.1.0": "bafybeidyojmjei4ltywtrrgdwem6makkigf7qm3kl5p65dsfb3xphddihy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeifpgso5dtosq5pb34fhjbihidstekdc77ijtbybsvnb3azqjamany",
-        "service/dvilela/memeooorr/0.1.0": "bafybeihyyn6mgevxuzklnu4de3nic7pbep5yyox2zepjnbilddqgsompw4"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeigfwnhjtf5rf5urgmafsgejd4acofqag52sqrvh4wazbp5fxwbj3q",
+        "service/dvilela/memeooorr/0.1.0": "bafybeic4wyhdbutrxdurgn6grdpjrqvflf6y7yj2y45edchwnp2hhmalta"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/scripts/aea-config-replace.py
+++ b/scripts/aea-config-replace.py
@@ -47,6 +47,7 @@ PATH_TO_VAR = {
     "models/params/args/skip_engagement": "SKIP_ENGAGEMENT",
     "models/params/args/staking_token_contract_address": "STAKING_TOKEN_CONTRACT_ADDRESS",
     "models/params/args/activity_checker_contract_address": "ACTIVITY_CHECKER_CONTRACT_ADDRESS",
+    "models/params/args/store_path": "STORE_PATH",
     # Tweepy connection
     "config/tweepy_consumer_api_key": "TWEEPY_CONSUMER_API_KEY",
     "config/tweepy_consumer_api_key_secret": "TWEEPY_CONSUMER_API_KEY_SECRET",


### PR DESCRIPTION
### This PR contains changes related to the storage location change to /data and media in a sub-dir 

## changes in files :

### aea-config.yaml , skill.yaml (both) , service.yaml , aea-config-replace.py ,
1. added store_path for agent behaviour in params

### twikit connection.py 
1. change default location from /tmp to /data

### base.py
1. added a new function to store the media info as a list in KV
2. added a function to read the data from the same list and flatten it 
3. another clean up function makes sure that we do not store more than 20 media files in the disk as well as in KV

### Mech.py

1. moved away from tempfile lib to use /data/media path for storing data
2. removed the tempfile cleanup function
3. use the `_store_media_info_list` fn to store media info 

