### PR TITLE
Fixing uninitialised data access for new agent

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeidxmipejo23ruw6jwzaihd32ldwc67r5ev6fn5mjwq5hmeg7or5za
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeibjoylbpwygpplagdhqzliw27ntfhg3bu452m5oozovejtd7w3eue
+- dvilela/memeooorr_abci:0.1.0:bafybeihimp767qep33mj67yg5du5pgn7qzn4ufqvhh7pv6yhcpbaw73sgu
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeicyuckyb72cmwt36kwgrvwgrvtjyz2wbqsxwvjbl4hnghs4bh7mdi
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy
 default_ledger: ethereum

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,10 +43,10 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeigt54dr5a5u4zrngwvk7uao4wlybjj6qlw5fkk6flm6j3iwekav6i
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeibwrjowq47efmduvpsx746374nidnx7ku46cqqc4sazqhkqwddchu
+- dvilela/memeooorr_abci:0.1.0:bafybeibeyk7i4cm4cjwi2j5atqya2qmdpeno5ewlz35me465p2g7djjl4u
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeiabvs4nlmdbmofdmhgzl4ghojwfoi73qqpd5ykejlbgmnuydylphi
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
-- valory/agent_db_abci:0.1.0:bafybeib5ukb2kduuv6zjltyj5ycv3d6gqbqmw2ilcrd4o6g6rsjbggf4ey
+- valory/agent_db_abci:0.1.0:bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeihzf7fw5aa55mdc353xxamhvf5lg47eee2dwnu4iusduf3tsyuo4y
+agent: dvilela/memeooorr:0.1.0:bafybeibrhsdj6zrepusx3etjua6vf4ouqbrepweu2gekyosjnfcyervoei
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeidbfjxfwyxdbvgtmt5ajcrhp5w5k5sq2it7vasc72qik2bcdeoc7y
+agent: dvilela/memeooorr:0.1.0:bafybeig63uafzouholxgjlzxtlpefnzo56qf3e54qo5du6tywrtshjdzua
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -46,7 +46,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifclzgoyulkyyigcwrqzmydyrj6c5d26xu7jk6cjbsed3pkls4pba
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
-- valory/agent_db_abci:0.1.0:bafybeib5ukb2kduuv6zjltyj5ycv3d6gqbqmw2ilcrd4o6g6rsjbggf4ey
+- valory/agent_db_abci:0.1.0:bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy
 behaviours:
   main:
     args: {}

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeigt54dr5a5u4zrngwvk7uao4wlybjj6qlw5fkk6flm6j3iwekav6i
+- dvilela/memeooorr_abci:0.1.0:bafybeibeyk7i4cm4cjwi2j5atqya2qmdpeno5ewlz35me465p2g7djjl4u
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeidxmipejo23ruw6jwzaihd32ldwc67r5ev6fn5mjwq5hmeg7or5za
+- dvilela/memeooorr_abci:0.1.0:bafybeihimp767qep33mj67yg5du5pgn7qzn4ufqvhh7pv6yhcpbaw73sgu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeigt54dr5a5u4zrngwvk7uao4wlybjj6qlw5fkk6flm6j3iwekav6i",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeibwrjowq47efmduvpsx746374nidnx7ku46cqqc4sazqhkqwddchu",
-        "skill/valory/agent_db_abci/0.1.0": "bafybeib5ukb2kduuv6zjltyj5ycv3d6gqbqmw2ilcrd4o6g6rsjbggf4ey",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeidbfjxfwyxdbvgtmt5ajcrhp5w5k5sq2it7vasc72qik2bcdeoc7y",
-        "service/dvilela/memeooorr/0.1.0": "bafybeiay7aoe7b4ees73ah4sc4iae7pz2tes5otqzstf44cwfqmyur7any"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeibeyk7i4cm4cjwi2j5atqya2qmdpeno5ewlz35me465p2g7djjl4u",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeiabvs4nlmdbmofdmhgzl4ghojwfoi73qqpd5ykejlbgmnuydylphi",
+        "skill/valory/agent_db_abci/0.1.0": "bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeig63uafzouholxgjlzxtlpefnzo56qf3e54qo5du6tywrtshjdzua",
+        "service/dvilela/memeooorr/0.1.0": "bafybeievzr3lgcvgyhmtu45kojeeyvxtoivpmppsodmcumsbs57tpwctmy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
         "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidxmipejo23ruw6jwzaihd32ldwc67r5ev6fn5mjwq5hmeg7or5za",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeibjoylbpwygpplagdhqzliw27ntfhg3bu452m5oozovejtd7w3eue",
-        "skill/valory/agent_db_abci/0.1.0": "bafybeib5ukb2kduuv6zjltyj5ycv3d6gqbqmw2ilcrd4o6g6rsjbggf4ey",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeihzf7fw5aa55mdc353xxamhvf5lg47eee2dwnu4iusduf3tsyuo4y",
-        "service/dvilela/memeooorr/0.1.0": "bafybeie7wdxqjk7q22mplm7ueldnzc4klvvgveihe5cz56ma2jjxpv2qsy"
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeihimp767qep33mj67yg5du5pgn7qzn4ufqvhh7pv6yhcpbaw73sgu",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeicyuckyb72cmwt36kwgrvwgrvtjyz2wbqsxwvjbl4hnghs4bh7mdi",
+        "skill/valory/agent_db_abci/0.1.0": "bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy",
+        "agent/dvilela/memeooorr/0.1.0": "bafybeibrhsdj6zrepusx3etjua6vf4ouqbrepweu2gekyosjnfcyervoei",
+        "service/dvilela/memeooorr/0.1.0": "bafybeihzqp4ngizep7kc5h6fj5pbyq56qj5nst42c7l6ehbrq6gjpb5sai"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",

--- a/packages/valory/skills/agent_db_abci/agents_fun_db.py
+++ b/packages/valory/skills/agent_db_abci/agents_fun_db.py
@@ -182,8 +182,15 @@ class AgentsFunDatabase(Model):
 
     def load(self):
         """Load data"""
+        yield from self.client._ensure_agent_instance()
         if self.agent_type is None:
-            self.agent_type = yield from self.client.get_agent_type_by_type_name(MEMEOOORR)
+            self.agent_type = yield from self.client.get_agent_type_by_type_name(
+                MEMEOOORR
+            )
+
+        if not self.agent_type:
+            self.logger.error(f"Could not get agent type {MEMEOOORR}")
+            return
 
         agent_instances = yield from self.client.get_agent_instances_by_type_id(
             self.agent_type.type_id
@@ -193,6 +200,10 @@ class AgentsFunDatabase(Model):
             yield from self.agents[-1].load()
             if self.agents[-1].agent_instance.eth_address == self.client.address:
                 self.my_agent = self.agents[-1]
+
+        if not self.my_agent and self.client.agent:
+            self.my_agent = AgentsFunAgent(self.client, self.client.agent)
+            self.agents.append(self.my_agent)
 
     def get_tweet_likes_number(self, tweet_id) -> int:
         """Get all tweet likes"""

--- a/packages/valory/skills/agent_db_abci/skill.yaml
+++ b/packages/valory/skills/agent_db_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeigmk5a3fgwudb2kysbh7ar3sdlunfxxrj76udkj555z5zz6onurdi
   agent_db_client.py: bafybeiavo5mzif3f5lg7czyiqnpldhfk2lx5kx22iozwavqfsl6m7rtnfa
   agent_db_models.py: bafybeieujj532ijrpcqgzgdb5rtvkrzdyv6j6uoz7r7v45kc5t4tgzl7au
-  agents_fun_db.py: bafybeiblunuvt5xsikj77ueblgdyhimhpjirpyjjhw4qs4g7fyw6x7glj4
+  agents_fun_db.py: bafybeic2kwa3bb74tqwzgssio33qai32pskig7gntbsztkejre5cws4xm4
   behaviours.py: bafybeify4fujvhgevulgvchkc2s53i3jf3xxwo2el5yoi6xzxfh52f7uj4
   dialogues.py: bafybeihsfzez4dsemudres2je4ksjcngbw5q72ltyucqtv5ytkpverqpry
   fsm_specification.yaml: bafybeigiboab2knxjw7jj7k7bne6osbnhs7rreo3mgtq5nfkrtpw47thze


### PR DESCRIPTION
This PR resolves issues with agent registration by ensuring the agent is registered in agent.db before its details, such as twitter_name, are accessed during init_own_details. Previously, registration occurred after agent loading, leading to potential access of uninitialized data