### PR TITLE
Bugfix/handle tweepy missing creds

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -13,7 +13,7 @@ connections:
 - valory/http_client:0.23.0:bafybeid5ffvg76ejjoese7brj5ji3lx66cu7p2ixfwflpo6rgofkypfd7y
 - valory/ledger:0.19.0:bafybeibdsjmy4w2eyilbqc7yzutopl65qpeyspxwz7mjvirr52twhjlf5y
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
-- dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
+- dvilela/tweepy:0.1.0:bafybeiduyb342noofhd3e323ixpqh52aqkryh3wqnqcw2scigiun2whjfq
 - dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeidfr5pjyvydtcbvfh3ip7htmeyt5y3mp7g2ng7hwyucshspi73i5i
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeia7sjqrs37q4bl3zqfu6q6f3ctsiuy2gc747nshzgev63f3p56jve
+- dvilela/memeooorr_abci:0.1.0:bafybeihif77kh7uw7le4p6637zsv6lrujzq7klkk2iwe6wqlkpcd2ilnrq
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeiarssd6un53ufcfutbjrkux5p76gjelyqh4fjbqr6kt3ybt2dtzlu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy
 default_ledger: ethereum

--- a/packages/dvilela/connections/tweepy/connection.yaml
+++ b/packages/dvilela/connections/tweepy/connection.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeicrwqrdownfmeyvvzu45fllxouiwvtynrzs5fhbpt3wndyyhn66eu
-  connection.py: bafybeienxlo7bkj57niiotqm3zo4sagioygdwk3ewlmzgozpi7bte6sucm
+  connection.py: bafybeihpkkzzny3henghicpaegnhzl3g5oskm2p5vguweugi7gitw7x5fy
   readme.md: bafybeib5oflnp3gymrottersu6qrnitjmaifl2gvbvjq7kbmsdbihhzfaa
   tweepy_wrapper.py: bafybeiduf2ogkjxvzw7hnuf3googhnuk2hdwvxhnc7cqiq7zfkkzte3sda
 fingerprint_ignore_patterns: []

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeicveqdhfa77hw2hu5uiaq6im2a2ebup2r42ydt5v57ji5kjlawi5e
+agent: dvilela/memeooorr:0.1.0:bafybeifkpybfjel7ppvol4kfln44fjrcaejqtyvji2qxzrfevinibjv74y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -215,7 +215,11 @@ class MemeooorrBaseBehaviour(
             self.context.logger.error(f"Error from Tweepy connection: {error_str}")
 
             # Check for indicators of a Forbidden error in the error string
-            if "Forbidden" in error_str or "403" in error_str:
+            if (
+                "Forbidden" in error_str
+                or "403" in error_str
+                or "credentials" in error_str.lower()
+            ):
                 self.context.logger.warning(
                     f"A Tweepy Forbidden error occurred (detected by string content): {error_str}"
                 )

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidorrnxjv4n4ngovxnu4mzod46kyrdncfmli4hapqeqnzp7imq7hm
   behaviour_classes/__init__.py: bafybeicjks4kxsb2r6a4armmaqxyxngwm3pouegq3fycm37rbe7otiwsre
-  behaviour_classes/base.py: bafybeigweoxukw5zxwe5dtl4sp24dra5pxaymyqdnre2cptxt57ithojzq
+  behaviour_classes/base.py: bafybeicidpwel6hrydbmb6alhwkmohymowc2w54ogdpqfjbpizb56pludy
   behaviour_classes/chain.py: bafybeig2qifmzybweuff6j5e35opqq6ownq6aosxd2vnt7tc266dfpicam
   behaviour_classes/db.py: bafybeibmwsyqcvy524vwqzmcyk7ghqhk75sbnyk4yt5eqvez775qvubf3i
   behaviour_classes/llm.py: bafybeif2kzc2pwme6fkaneswnw4b6pk56xbwqsqbe5ljvw4vt4iylnb7dm
@@ -26,7 +26,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - dvilela/kv_store:0.1.0:bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai
-- dvilela/tweepy:0.1.0:bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva
+- dvilela/tweepy:0.1.0:bafybeiduyb342noofhd3e323ixpqh52aqkryh3wqnqcw2scigiun2whjfq
 - dvilela/genai:0.1.0:bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty
 - valory/http_server:0.22.0:bafybeic3jpkum7g6qo6x6vdrmvvhj7vqw7ec2op72uc3yfhmnlp5hn3joy
 contracts:

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeidfr5pjyvydtcbvfh3ip7htmeyt5y3mp7g2ng7hwyucshspi73i5i
+- dvilela/memeooorr_abci:0.1.0:bafybeihif77kh7uw7le4p6637zsv6lrujzq7klkk2iwe6wqlkpcd2ilnrq
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/dvilela/mirror_db/0.1.0": "bafybeifgjuwvqpjafwkdqjt4223i7jdm6ppyijdx2knox4md7tfbhpvmbq",
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeidsmswryxifxmkichzwsm2bvongcei2tlz3tcs45rabvm7eu5g5ai",
-        "connection/dvilela/tweepy/0.1.0": "bafybeig5uthh7e3jliec5poawflbtkdhuen5c33hzsejz5wvbweg4bcvva",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeidfr5pjyvydtcbvfh3ip7htmeyt5y3mp7g2ng7hwyucshspi73i5i",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeia7sjqrs37q4bl3zqfu6q6f3ctsiuy2gc747nshzgev63f3p56jve",
+        "connection/dvilela/tweepy/0.1.0": "bafybeiduyb342noofhd3e323ixpqh52aqkryh3wqnqcw2scigiun2whjfq",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeihif77kh7uw7le4p6637zsv6lrujzq7klkk2iwe6wqlkpcd2ilnrq",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeiarssd6un53ufcfutbjrkux5p76gjelyqh4fjbqr6kt3ybt2dtzlu",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeicveqdhfa77hw2hu5uiaq6im2a2ebup2r42ydt5v57ji5kjlawi5e",
-        "service/dvilela/memeooorr/0.1.0": "bafybeiaxotvxbiyuulzc7kbtpa735qerjdlhqqyeoqyrqpc4qm2b7eoyay"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeifkpybfjel7ppvol4kfln44fjrcaejqtyvji2qxzrfevinibjv74y",
+        "service/dvilela/memeooorr/0.1.0": "bafybeidrifmky3bynqwv3ibnipm2pzmsqwgwv5szybjy333dtypmnekdtq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",


### PR DESCRIPTION
The PR makes the agent capable of handling the tweepy creds absence

## changes 

### connection.py 

1. now if any of the creds are missing we send an error message to _call_tweepy fn in base.py
2. changed the type of tweepy_skip_auth to bool

### Base.py

1. the base .py now looks for credential in the error message and  