### PR TITLE
fix : agent-ui showing broken links

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -43,8 +43,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/registration_abci:0.1.0:bafybeigt7bmrfhet7fyafqojl2i5uhzvpaz5wfv6kuk5ojwhhnhmg3qihu
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
-- dvilela/memeooorr_abci:0.1.0:bafybeifxddobnwau434buuxq4mfpphkhib2mnwzfx2ryw6at24fkhpcsqy
-- dvilela/memeooorr_chained_abci:0.1.0:bafybeib7inngfcr6onqniprdbfyfcyjfic7dx2ihqwvy7gn7lthre2urtm
+- dvilela/memeooorr_abci:0.1.0:bafybeieurxnrztphnh5awqi5fceoxviffndse5a3sskeuysniqaurc3qaa
+- dvilela/memeooorr_chained_abci:0.1.0:bafybeifiug5g2vyftkomlqk3sy4ddwo3hfhbz5o3c5y3q5pyvqx3bl7vlu
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 - valory/agent_db_abci:0.1.0:bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy
 default_ledger: ethereum

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiaekcmielp6mb4qvmo2twwkpmoun36bqajrh7wnnkcpdnia45ycl4
 fingerprint_ignore_patterns: []
-agent: dvilela/memeooorr:0.1.0:bafybeidmwlp22icc2nvjas6tevixvwzxgi5c2kw2n77i3wvcwkeg4y26aa
+agent: dvilela/memeooorr:0.1.0:bafybeihxlzohhj5o3fjf6x5n3kwsvcwx54go4qfh26qw2zhytxwobysxau
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -26,7 +26,7 @@ fingerprint:
   behaviours.py: bafybeicsif4jpkuq4a5ijgj63s5zn4mskmakuddgiquqb4vrlz3trqa7fu
   dialogues.py: bafybeiaygigeleloplgrsg2sovv463uvzk3zc2tupgazn4ak2vqcangksu
   fsm_specification.yaml: bafybeicjoerr5nakbcpvk5ygoxqdrassyo6qxym6and6blfebvrhuy7ld4
-  handlers.py: bafybeib3x3rubfuzonz64ckcqwanwluksm6dekin5mhgh62wc6xkrn42zu
+  handlers.py: bafybeig2g4fk5y6wxgtxqmaakmwkzipsmu7idf4snkgo22s2gygcxj4ida
   models.py: bafybeihttpkqc4tzsttf3c24tz5327ixazteu7gtfulvgdsl42zwvbdelq
   payloads.py: bafybeibkyns7pplvrfcimq4umyufvvk6of4pbqqkqzmxpqwbwmmshcf6xe
   prompts.py: bafybeid6dxm6jbn6ebiy62s56edfahivwsxge4grdlexen6lbnz3mctbvi

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -23,7 +23,7 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicskv7u3mtfhi7nnoyw3bppwjof63izs4jgqdddtxicoea26t2n7i
 - valory/transaction_settlement_abci:0.1.0:bafybeid4alawv3oz4gdyom5uevrgzfsahbwabi37r7gomsetwqiq66g6cm
 - valory/termination_abci:0.1.0:bafybeianygjbwmt4xrq77pfl3yzcokbjfzxmuru6j2k7a3boqc2qfb7shi
-- dvilela/memeooorr_abci:0.1.0:bafybeifxddobnwau434buuxq4mfpphkhib2mnwzfx2ryw6at24fkhpcsqy
+- dvilela/memeooorr_abci:0.1.0:bafybeieurxnrztphnh5awqi5fceoxviffndse5a3sskeuysniqaurc3qaa
 - valory/mech_interact_abci:0.1.0:bafybeibhigcn46vxrqwcmygin4v442qknyklmuaufyre2npca26sbmkdvu
 behaviours:
   main:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,11 +9,11 @@
         "connection/dvilela/genai/0.1.0": "bafybeihp6t4y7mynitwj3afwet2lr5ittrqmk4hop7ycmgyyx3nqkc5sty",
         "connection/dvilela/kv_store/0.1.0": "bafybeieufzdojxahh3ejagdbzroqredi5uvkfgjiwsfod7l7whn2octmmi",
         "connection/dvilela/tweepy/0.1.0": "bafybeicxb4kdudg2eysq2kbopgss23smwoccujfpaar6td6egqkw5ovau4",
-        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeifxddobnwau434buuxq4mfpphkhib2mnwzfx2ryw6at24fkhpcsqy",
-        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeib7inngfcr6onqniprdbfyfcyjfic7dx2ihqwvy7gn7lthre2urtm",
+        "skill/dvilela/memeooorr_abci/0.1.0": "bafybeieurxnrztphnh5awqi5fceoxviffndse5a3sskeuysniqaurc3qaa",
+        "skill/dvilela/memeooorr_chained_abci/0.1.0": "bafybeifiug5g2vyftkomlqk3sy4ddwo3hfhbz5o3c5y3q5pyvqx3bl7vlu",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiffsljyu4vhhkdclmymmpndlw42bqeuouahluwk7k7r3djvo4rgpy",
-        "agent/dvilela/memeooorr/0.1.0": "bafybeidmwlp22icc2nvjas6tevixvwzxgi5c2kw2n77i3wvcwkeg4y26aa",
-        "service/dvilela/memeooorr/0.1.0": "bafybeiamqfiub2stttwico4nxoodz3kiv4jllkp4acsisfpq6k6zeym3ue"
+        "agent/dvilela/memeooorr/0.1.0": "bafybeihxlzohhj5o3fjf6x5n3kwsvcwx54go4qfh26qw2zhytxwobysxau",
+        "service/dvilela/memeooorr/0.1.0": "bafybeiardecju3sygh7hwuywka2bgjinbr7vrzob4mpdrookyfsbdmoq2m"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm",


### PR DESCRIPTION
This PR fixes issues with recent activity returning a broken post from twitter

now if we do not have any post id present for that token activity (ideally should never happen , but it does most probably due to tweepy rate limit - assuming)

we do not show it to the user , we show the previous one 