### PR TITLE
[Revival 2] feat: add logic to skip all memecoin stuff

### DIFF
--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -247,6 +247,7 @@ models:
       use_acn_for_delivers: false
       summon_cooldown_seconds: ${int:2592000}
       heart_cooldown_hours: ${int:48}
+      is_memecoin_logic_enabled: ${bool:false}
 ---
 public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -119,6 +119,7 @@ extra:
         use_acn_for_delivers: false
         summon_cooldown_seconds: ${SUMMON_COOLDOWN_SECONDS:int:2592000}
         heart_cooldown_hours: ${HEART_COOLDOWN_HOURS:int:48}
+        is_memecoin_logic_enabled: ${IS_MEMECOIN_LOGIC_ENABLED:bool:false}
 ---
 public_id: valory/ledger:0.19.0
 type: connection

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/chain.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/chain.py
@@ -30,6 +30,7 @@ from packages.dvilela.contracts.meme_factory.contract import MemeFactoryContract
 from packages.dvilela.skills.memeooorr_abci.behaviour_classes.base import (
     MemeooorrBaseBehaviour,
 )
+from packages.dvilela.skills.memeooorr_abci.models import Params
 from packages.dvilela.skills.memeooorr_abci.rounds import (
     ActionPreparationPayload,
     ActionPreparationRound,
@@ -609,17 +610,33 @@ class PullMemesBehaviour(ChainBehaviour):  # pylint: disable=too-many-ancestors
 
     matching_round: Type[AbstractRound] = PullMemesRound
 
+    @property
+    def params(self) -> Params:
+        return self.context.params
+
     def async_act(self) -> Generator:
         """Do the act, supporting asynchronous execution."""
 
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
-            meme_coins = yield from self.get_meme_coins()
-            self.context.logger.info(f"Meme token list: {meme_coins}")
 
-            payload = PullMemesPayload(
-                sender=self.context.agent_address,
-                meme_coins=json.dumps(meme_coins, sort_keys=True),
-            )
+            if not self.params.is_memecoin_logic_enabled:
+                self.context.logger.info(
+                    "Meme-coin logic is disabled. Skipping token pull operation."
+                )
+                payload = PullMemesPayload(
+                    sender=self.context.agent_address,
+                    event=Event.SKIP.value,
+                )
+
+            else:
+                meme_coins = yield from self.get_meme_coins()
+                self.context.logger.info(f"Meme token list: {meme_coins}")
+
+                payload = PullMemesPayload(
+                    sender=self.context.agent_address,
+                    meme_coins=json.dumps(meme_coins, sort_keys=True),
+                    event=Event.DONE.value,
+                )
 
         with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
             yield from self.send_a2a_transaction(payload)

--- a/packages/dvilela/skills/memeooorr_abci/fsm_specification.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/fsm_specification.yaml
@@ -54,6 +54,7 @@ transition_func:
     (ActionDecisionRound, RETRY): ActionDecisionRound
     (ActionDecisionRound, ROUND_TIMEOUT): ActionDecisionRound
     (ActionDecisionRound, WAIT): CallCheckpointRound
+    (ActionDecisionRound, SKIP): CallCheckpointRound
     (ActionPreparationRound, DONE): ActionTweetRound
     (ActionPreparationRound, ERROR): CallCheckpointRound
     (ActionPreparationRound, NO_MAJORITY): ActionPreparationRound
@@ -106,6 +107,7 @@ transition_func:
     (PostTxDecisionMakingRound, NO_MAJORITY): PostTxDecisionMakingRound
     (PostTxDecisionMakingRound, ROUND_TIMEOUT): PostTxDecisionMakingRound
     (PullMemesRound, DONE): CollectFeedbackRound
+    (PullMemesRound, SKIP): CollectFeedbackRound
     (PullMemesRound, NO_MAJORITY): PullMemesRound
     (PullMemesRound, ROUND_TIMEOUT): PullMemesRound
     (TransactionLoopCheckRound, DONE): FinishedToResetRound

--- a/packages/dvilela/skills/memeooorr_abci/models.py
+++ b/packages/dvilela/skills/memeooorr_abci/models.py
@@ -189,4 +189,8 @@ class Params(MechParams):  # pylint: disable=too-many-instance-attributes
         self.store_path = self._ensure("store_path", kwargs, str)
         self.heart_cooldown_hours = self._ensure("heart_cooldown_hours", kwargs, int)
 
+        self.is_memecoin_logic_enabled = self._ensure(
+            "is_memecoin_logic_enabled", kwargs, bool
+        )
+
         super().__init__(*args, **kwargs)

--- a/packages/dvilela/skills/memeooorr_abci/payloads.py
+++ b/packages/dvilela/skills/memeooorr_abci/payloads.py
@@ -46,7 +46,8 @@ class CheckStakingPayload(BaseTxPayload):
 class PullMemesPayload(BaseTxPayload):
     """Represent a transaction payload for the PullMemesRound."""
 
-    meme_coins: Optional[str]
+    meme_coins: Optional[str] = None
+    event: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/packages/dvilela/skills/memeooorr_abci/prompts.py
+++ b/packages/dvilela/skills/memeooorr_abci/prompts.py
@@ -237,6 +237,16 @@ TOKEN_DECISION_PROMPT = (  # nosec
     """
 )
 
+ONLY_PERSONA_UPDATE_PROMPT = """You are an agent with a specific persona. You create tweets based on it.
+
+    Here's your latest tweet:
+    "{latest_tweet}"
+
+    Here's a list of tweets that you received as a response to your latest tweet.
+    You can use this information to update your persona if you think that will improve engagement.
+    "{tweet_responses}"
+    """  # nosec
+
 ALTERNATIVE_MODEL_TOKEN_PROMPT = (  # nosec
     ""
     """
@@ -359,6 +369,18 @@ class TokenAction:  # pylint: disable=too-many-instance-attributes
 def build_token_action_schema() -> dict:
     """Build a schema for token action response"""
     return {"class": pickle.dumps(TokenAction).hex(), "is_list": False}
+
+
+@dataclass(frozen=True)
+class PersonaAction:  # pylint: disable=too-many-instance-attributes
+    """PersonaAction"""
+
+    new_persona: typing.Optional[str]
+
+
+def build_persona_action_schema() -> dict:
+    """Build a schema for persona action response"""
+    return {"class": pickle.dumps(PersonaAction).hex(), "is_list": False}
 
 
 CHATUI_PROMPT = """

--- a/packages/dvilela/skills/memeooorr_abci/rounds.py
+++ b/packages/dvilela/skills/memeooorr_abci/rounds.py
@@ -345,6 +345,8 @@ class PullMemesRound(CollectSameUntilThresholdRound):
         # Event.DONE, Event.NO_MAJORITY, Event.ROUND_TIMEOUT
 
         if self.threshold_reached:
+            if self.most_voted_payload_values[1] == Event.SKIP.value:
+                return self.synchronized_data, Event.SKIP
             if self.most_voted_payload is None:
                 meme_coins = []
             else:
@@ -832,6 +834,7 @@ class MemeooorrAbciApp(AbciApp[Event]):
         },
         PullMemesRound: {
             Event.DONE: CollectFeedbackRound,
+            Event.SKIP: CollectFeedbackRound,
             Event.NO_MAJORITY: PullMemesRound,
             Event.ROUND_TIMEOUT: PullMemesRound,
         },
@@ -851,6 +854,7 @@ class MemeooorrAbciApp(AbciApp[Event]):
         ActionDecisionRound: {
             Event.DONE: ActionPreparationRound,
             Event.WAIT: CallCheckpointRound,
+            Event.SKIP: CallCheckpointRound,
             Event.RETRY: ActionDecisionRound,
             Event.NO_MAJORITY: ActionDecisionRound,
             Event.ROUND_TIMEOUT: ActionDecisionRound,

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -228,6 +228,7 @@ models:
         frequency_penalty: 0
         temperature": 0.6
       fireworks_api_key: null
+      is_memecoin_logic_enabled: false
     class_name: Params
   mech_response:
     args:

--- a/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
@@ -69,6 +69,7 @@ transition_func:
     (ActionDecisionRound, RETRY): ActionDecisionRound
     (ActionDecisionRound, ROUND_TIMEOUT): ActionDecisionRound
     (ActionDecisionRound, WAIT): CallCheckpointRound
+    (ActionDecisionRound, SKIP): CallCheckpointRound
     (ActionPreparationRound, DONE): ActionTweetRound
     (ActionPreparationRound, ERROR): CallCheckpointRound
     (ActionPreparationRound, NO_MAJORITY): ActionPreparationRound
@@ -149,6 +150,7 @@ transition_func:
     (PostTxDecisionMakingRound, NO_MAJORITY): PostTxDecisionMakingRound
     (PostTxDecisionMakingRound, ROUND_TIMEOUT): PostTxDecisionMakingRound
     (PullMemesRound, DONE): CollectFeedbackRound
+    (PullMemesRound, SKIP): CollectFeedbackRound
     (PullMemesRound, NO_MAJORITY): PullMemesRound
     (PullMemesRound, ROUND_TIMEOUT): PullMemesRound
     (RandomnessTransactionSubmissionRound, DONE): SelectKeeperTransactionSubmissionARound

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -195,6 +195,7 @@ models:
         frequency_penalty: 0
         temperature": 0.6
       fireworks_api_key: null
+      is_memecoin_logic_enabled: false
     class_name: Params
   randomness_api:
     args:

--- a/scripts/aea-config-replace.py
+++ b/scripts/aea-config-replace.py
@@ -66,6 +66,8 @@ PATH_TO_VAR = {
     "models/params/args/fireworks_api_key": "FIREWORKS_API_KEY",
     # Cooldown
     "models/params/args/summon_cooldown_seconds": "SUMMON_COOLDOWN_SECONDS",
+    # Memecoin
+    "models/params/args/is_memecoin_logic_enabled": "IS_MEMECOIN_LOGIC_ENABLED",
 }
 
 CONFIG_REGEX = r"\${.*?:(.*)}"


### PR DESCRIPTION
This PR:
1. Skips all the logic in `PullMemesRound` as meme coins data from subgraph would no longer be needed
2. Skips most of the logic in `ActionDecisionBehaviour`
    - Automatic persona updation is still kept in
    - Skips `ActionPreparationRound` 

PR Chain:
1. https://github.com/dvilelaf/meme-ooorr/pull/279
2. https://github.com/dvilelaf/meme-ooorr/pull/280
3. https://github.com/dvilelaf/meme-ooorr/pull/281

Note: CI would be fixed in the very last PR. (This PR doesn't point to main)