### PR TITLE
[Revival 7] Adds agent performance summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages/valory/contracts/*
 !packages/valory/contracts/staking_activity_checker
 packages/valory/protocols/
 packages/valory/skills/*
+!packages/valory/skills/agent_performance_summary_abci
 !packages/valory/skills/agent_db_abci
 packages/valory/connections/*
 packages/dvilela/connections/genai
@@ -32,6 +33,7 @@ __pycache__/
 .vscode/launch.json
 .vscode/settings.json
 
+data/
 memeooorr.db
 
 TODO.md

--- a/packages/dvilela/agents/memeooorr/aea-config.yaml
+++ b/packages/dvilela/agents/memeooorr/aea-config.yaml
@@ -253,6 +253,8 @@ models:
       x402_payment_requirements: ${dict:{"threshold":200000,"top_up":250000}}
       base_ledger_rpc: ${str:https://1rpc.io/base}
       lifi_quote_to_amount_url: ${str:https://li.quest/v1/quote/toAmount}
+      is_agent_performance_summary_enabled: ${bool:true}
+      performance_summary_ttl: ${int:1800}
 ---
 public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection

--- a/packages/dvilela/connections/tweepy/tweepy_wrapper.py
+++ b/packages/dvilela/connections/tweepy/tweepy_wrapper.py
@@ -244,3 +244,29 @@ class Twitter:
                 f"TweepyException in method get_follower_ids: {type(e).__name__} - {e}"
             )
             raise
+
+    def get_all_user_tweets(
+        self,
+        user_id: str,
+        max_results: int = 100,
+        tweet_fields: Optional[List[str]] = None,
+    ) -> Dict:
+        """Get a user's tweets."""
+        try:
+            paginator = tweepy.Paginator(
+                self.client.get_users_tweets,
+                user_id,
+                max_results=max_results,
+                tweet_fields=tweet_fields,
+            )
+            all_tweets = []
+            for response in paginator:
+                if response.data:
+                    all_tweets.extend(response.data)
+
+            return all_tweets
+        except tweepy.errors.TweepyException as e:
+            self.logger.error(
+                f"TweepyException in method get_user_tweets_with_public_metrics: {type(e).__name__} - {e}"
+            )
+            raise

--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -125,6 +125,8 @@ extra:
         x402_payment_requirements: ${X402_PAYMENT_REQUIREMENTS:dict:{"threshold":200000,"top_up":250000}}
         base_ledger_rpc: ${BASE_LEDGER_RPC:str:https://1rpc.io/base}
         lifi_quote_to_amount_url: ${LIFI_QUOTE_TO_AMOUNT_URL:str:https://li.quest/v1/quote/toAmount}
+        is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
+        performance_summary_ttl: ${PERFORMANCE_SUMMARY_TTL:int:1800}
 ---
 public_id: valory/ledger:0.19.0
 type: connection

--- a/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
+++ b/packages/dvilela/skills/memeooorr_abci/behaviour_classes/base.py
@@ -1002,35 +1002,47 @@ class MemeooorrBaseBehaviour(
         return tweet
 
     def init_own_twitter_details(self) -> Generator[None, None, None]:
-        """Initialize own Twitter account details."""
+        """Initialize own Twitter account details, preferring state, and only writing to DB if initialized."""
 
-        if (
-            self.context.state.twitter_username is not None
-            and self.context.state.twitter_id is not None
-        ):
-            return
+        db_agent = self.context.agents_fun_db.my_agent
+        db_initialized = db_agent is not None  # safeguard
 
-        account_details = yield from self._call_tweepy(
-            method="get_me",
-        )
+        # --- CASE 1: State already initialized ---
+        if self.context.state.twitter_username and self.context.state.twitter_id:
+            print("Using cached Twitter details from state.")
+
+            if db_initialized:
+                # If DB missing values, sync from state
+                if not db_agent.twitter_username or not db_agent.twitter_user_id:
+                    db_agent.twitter_username = self.context.state.twitter_username
+                    db_agent.twitter_user_id = self.context.state.twitter_id
+                    yield from db_agent.update_twitter_details()
+
+            return  # Done, no external call
+
+        # --- CASE 2: State missing, fetch from Twitter ---
+        account_details = yield from self._call_tweepy(method="get_me")
         if not account_details:
             self.context.logger.error("Couldn't fetch own Twitter account details.")
             return
+
+        # Update state
         self.context.state.twitter_username = account_details.get("username")
         self.context.state.twitter_id = account_details.get("user_id")
         self.context.state.twitter_display_name = account_details.get("display_name")
 
-        self.context.agents_fun_db.my_agent.twitter_username = (
-            self.context.state.twitter_username
-        )
-        self.context.agents_fun_db.my_agent.twitter_user_id = (
-            self.context.state.twitter_id
-        )
-        if (
-            self.context.agents_fun_db.my_agent.twitter_username
-            and self.context.agents_fun_db.my_agent.twitter_user_id
-        ):
-            yield from self.context.agents_fun_db.my_agent.update_twitter_details()
+        print("Fetched Twitter details from API & updated state.")
+
+        # --- CASE 3: DB not initialized → stop here ---
+        if not db_initialized:
+            print("DB not initialized — skipping DB update.")
+            return
+
+        # --- CASE 4: DB initialized, update it too ---
+        db_agent.twitter_username = self.context.state.twitter_username
+        db_agent.twitter_user_id = self.context.state.twitter_id
+
+        yield from db_agent.update_twitter_details()
 
     def _store_agent_action(
         self, action_type: str, action_data: Any

--- a/packages/dvilela/skills/memeooorr_abci/models.py
+++ b/packages/dvilela/skills/memeooorr_abci/models.py
@@ -187,7 +187,7 @@ class Params(MechParams):  # pylint: disable=too-many-instance-attributes
         self.summon_cooldown_seconds = self._ensure(
             "summon_cooldown_seconds", kwargs, int
         )
-        self.store_path = self._ensure("store_path", kwargs, str)
+        self.store_path = kwargs.get("store_path", "")
         self.heart_cooldown_hours = self._ensure("heart_cooldown_hours", kwargs, int)
 
         self.is_memecoin_logic_enabled = self._ensure(

--- a/packages/dvilela/skills/memeooorr_abci/rounds_info.py
+++ b/packages/dvilela/skills/memeooorr_abci/rounds_info.py
@@ -149,4 +149,8 @@ ROUNDS_INFO = {
         "name": "Post Mech response",
         "description": "Handles a post Mech response",
     },
+    "fetch_performance_data_round": {
+        "name": "Fetching agent performance summary",
+        "description": "Fetches the agent performance summary data",
+    },
 }

--- a/packages/dvilela/skills/memeooorr_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_abci/skill.yaml
@@ -233,6 +233,8 @@ models:
       x402_payment_requirements: {}
       base_ledger_rpc: https://1rpc.io/base
       lifi_quote_to_amount_url: https://li.quest/v1/quote/toAmount
+      is_agent_performance_summary_enabled: true
+      performance_summary_ttl: 1800
     class_name: Params
   mech_response:
     args:

--- a/packages/dvilela/skills/memeooorr_chained_abci/behaviours.py
+++ b/packages/dvilela/skills/memeooorr_chained_abci/behaviours.py
@@ -29,6 +29,9 @@ from packages.valory.skills.abstract_round_abci.behaviours import (
     AbstractRoundBehaviour,
     BaseBehaviour,
 )
+from packages.valory.skills.agent_performance_summary_abci.behaviours import (
+    AgentPerformanceSummaryRoundBehaviour,
+)
 from packages.valory.skills.mech_interact_abci.behaviours.round_behaviour import (
     MechInteractRoundBehaviour,
 )
@@ -55,6 +58,7 @@ class MemeooorrChainedConsensusBehaviour(AbstractRoundBehaviour):
     abci_app_cls = MemeooorrChainedSkillAbciApp
     behaviours: Set[Type[BaseBehaviour]] = {
         *AgentRegistrationRoundBehaviour.behaviours,
+        *AgentPerformanceSummaryRoundBehaviour.behaviours,
         *ResetPauseABCIConsensusBehaviour.behaviours,
         *MemeooorrRoundBehaviour.behaviours,
         *TerminationAbciBehaviours.behaviours,

--- a/packages/dvilela/skills/memeooorr_chained_abci/composition.py
+++ b/packages/dvilela/skills/memeooorr_chained_abci/composition.py
@@ -20,6 +20,7 @@
 """This package contains round behaviours of MemeooorrChainedSkillAbciApp."""
 
 import packages.dvilela.skills.memeooorr_abci.rounds as MemeooorrAbci
+import packages.valory.skills.agent_performance_summary_abci.rounds as AgentPerformanceSummaryAbci
 import packages.valory.skills.mech_interact_abci.rounds as MechInteractAbci
 import packages.valory.skills.mech_interact_abci.states.final_states as MechFinalStates
 import packages.valory.skills.mech_interact_abci.states.request as MechRequestStates
@@ -42,7 +43,8 @@ from packages.valory.skills.termination_abci.rounds import (
 # Here we define how the transition between the FSMs should happen
 # more information here: https://docs.autonolas.network/fsm_app_introduction/#composition-of-fsm-apps
 abci_app_transition_mapping: AbciAppTransitionMapping = {
-    RegistrationAbci.FinishedRegistrationRound: MemeooorrAbci.LoadDatabaseRound,
+    RegistrationAbci.FinishedRegistrationRound: AgentPerformanceSummaryAbci.FetchPerformanceDataRound,
+    AgentPerformanceSummaryAbci.FinishedFetchPerformanceDataRound: MemeooorrAbci.LoadDatabaseRound,
     MemeooorrAbci.FinishedToResetRound: ResetAndPauseAbci.ResetAndPauseRound,
     MemeooorrAbci.FinishedToSettlementRound: TransactionSettlementAbci.RandomnessTransactionSubmissionRound,
     TransactionSettlementAbci.FinishedTransactionSubmissionRound: MemeooorrAbci.PostTxDecisionMakingRound,
@@ -67,6 +69,7 @@ termination_config = BackgroundAppConfig(
 MemeooorrChainedSkillAbciApp = chain(
     (
         RegistrationAbci.AgentRegistrationAbciApp,
+        AgentPerformanceSummaryAbci.AgentPerformanceSummaryAbciApp,
         MemeooorrAbci.MemeooorrAbciApp,
         TransactionSettlementAbci.TransactionSubmissionAbciApp,
         ResetAndPauseAbci.ResetPauseAbciApp,

--- a/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
@@ -161,11 +161,11 @@ transition_func:
     (RegistrationRound, DONE): FetchPerformanceDataRound
     (RegistrationRound, NO_MAJORITY): RegistrationRound
     (RegistrationStartupRound, DONE): FetchPerformanceDataRound
-    (FetchPerformanceDataRound, DONE): CheckStakingRound
-    (FetchPerformanceDataRound, FAIL): CheckStakingRound
+    (FetchPerformanceDataRound, DONE): LoadDatabaseRound
+    (FetchPerformanceDataRound, FAIL): LoadDatabaseRound
     (FetchPerformanceDataRound, NONE): FetchPerformanceDataRound
     (FetchPerformanceDataRound, NO_MAJORITY): FetchPerformanceDataRound
-    (FetchPerformanceDataRound, ROUND_TIMEOUT): CheckStakingRound
+    (FetchPerformanceDataRound, ROUND_TIMEOUT): LoadDatabaseRound
     (ResetAndPauseRound, DONE): CheckStakingRound
     (ResetAndPauseRound, NO_MAJORITY): ResetAndPauseRound
     (ResetAndPauseRound, RESET_AND_PAUSE_TIMEOUT): ResetAndPauseRound

--- a/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/fsm_specification.yaml
@@ -62,6 +62,7 @@ states:
 - SelectKeeperTransactionSubmissionBRound
 - SynchronizeLateMessagesRound
 - TransactionLoopCheckRound
+- FetchPerformanceDataRound
 - ValidateTransactionRound
 transition_func:
     (ActionDecisionRound, DONE): ActionPreparationRound
@@ -157,9 +158,14 @@ transition_func:
     (RandomnessTransactionSubmissionRound, NONE): RandomnessTransactionSubmissionRound
     (RandomnessTransactionSubmissionRound, NO_MAJORITY): RandomnessTransactionSubmissionRound
     (RandomnessTransactionSubmissionRound, ROUND_TIMEOUT): RandomnessTransactionSubmissionRound
-    (RegistrationRound, DONE): LoadDatabaseRound
+    (RegistrationRound, DONE): FetchPerformanceDataRound
     (RegistrationRound, NO_MAJORITY): RegistrationRound
-    (RegistrationStartupRound, DONE): LoadDatabaseRound
+    (RegistrationStartupRound, DONE): FetchPerformanceDataRound
+    (FetchPerformanceDataRound, DONE): CheckStakingRound
+    (FetchPerformanceDataRound, FAIL): CheckStakingRound
+    (FetchPerformanceDataRound, NONE): FetchPerformanceDataRound
+    (FetchPerformanceDataRound, NO_MAJORITY): FetchPerformanceDataRound
+    (FetchPerformanceDataRound, ROUND_TIMEOUT): CheckStakingRound
     (ResetAndPauseRound, DONE): CheckStakingRound
     (ResetAndPauseRound, NO_MAJORITY): ResetAndPauseRound
     (ResetAndPauseRound, RESET_AND_PAUSE_TIMEOUT): ResetAndPauseRound

--- a/packages/dvilela/skills/memeooorr_chained_abci/models.py
+++ b/packages/dvilela/skills/memeooorr_chained_abci/models.py
@@ -33,7 +33,6 @@ from packages.dvilela.skills.memeooorr_abci.models import Params as MemeooorrPar
 from packages.dvilela.skills.memeooorr_abci.models import (
     RandomnessApi as MemeooorrRandomnessApi,
 )
-from packages.dvilela.skills.memeooorr_abci.models import SharedState as BaseSharedState
 from packages.dvilela.skills.memeooorr_abci.rounds import Event as MemeooorrEvent
 from packages.dvilela.skills.memeooorr_chained_abci.composition import (
     MemeooorrChainedSkillAbciApp,
@@ -42,6 +41,12 @@ from packages.valory.skills.abstract_round_abci.models import (
     BenchmarkTool as BaseBenchmarkTool,
 )
 from packages.valory.skills.abstract_round_abci.models import Requests as BaseRequests
+from packages.valory.skills.agent_performance_summary_abci.models import (
+    AgentPerformanceSummaryParams,
+)
+from packages.valory.skills.agent_performance_summary_abci.models import (
+    SharedState as BaseSharedState,
+)
 from packages.valory.skills.mech_interact_abci.models import (
     MechResponseSpecs as BaseMechResponseSpecs,
 )
@@ -96,5 +101,7 @@ class SharedState(BaseSharedState):
         )  # need to introduce a parameter for this
 
 
-class Params(MemeooorrParams, TerminationParams):  # pylint: disable=too-many-ancestors
+class Params(
+    MemeooorrParams, TerminationParams, AgentPerformanceSummaryParams
+):  # pylint: disable=too-many-ancestors
     """A model to represent params for multiple abci apps."""

--- a/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/dvilela/skills/memeooorr_chained_abci/skill.yaml
@@ -200,6 +200,8 @@ models:
       x402_payment_requirements: {}
       base_ledger_rpc: https://1rpc.io/base
       lifi_quote_to_amount_url: https://li.quest/v1/quote/toAmount
+      is_agent_performance_summary_enabled: true
+      performance_summary_ttl: 1800
     class_name: Params
   randomness_api:
     args:

--- a/packages/valory/skills/agent_performance_summary_abci/__init__.py
+++ b/packages/valory/skills/agent_performance_summary_abci/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the agent performance skill for an AEA."""
+
+from aea.configurations.base import PublicId
+
+
+PUBLIC_ID = PublicId.from_str("valory/agent_performance_summary_abci:0.1.0")

--- a/packages/valory/skills/agent_performance_summary_abci/behaviours.py
+++ b/packages/valory/skills/agent_performance_summary_abci/behaviours.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the behaviour of the skill which is responsible for agent performance summary file updation."""
+
+from typing import Any, Dict, Generator, List, Optional, Set, Type, cast
+
+from packages.dvilela.skills.memeooorr_abci.behaviour_classes.base import (
+    MemeooorrBaseBehaviour,
+)
+from packages.valory.skills.abstract_round_abci.base import BaseTxPayload
+from packages.valory.skills.abstract_round_abci.behaviours import (
+    AbstractRoundBehaviour,
+    BaseBehaviour,
+)
+from packages.valory.skills.agent_performance_summary_abci.models import (
+    AgentPerformanceMetrics,
+    AgentPerformanceSummary,
+    AgentPerformanceSummaryParams,
+    SharedState,
+)
+from packages.valory.skills.agent_performance_summary_abci.payloads import (
+    FetchPerformanceDataPayload,
+)
+from packages.valory.skills.agent_performance_summary_abci.rounds import (
+    AgentPerformanceSummaryAbciApp,
+    FetchPerformanceDataRound,
+)
+
+
+DEFAULT_MECH_FEE = 1e16  # 0.01 ETH
+QUESTION_DATA_SEPARATOR = "\u241f"
+PREDICT_MARKET_DURATION_DAYS = 4
+
+INVALID_ANSWER_HEX = (
+    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+)
+
+PERCENTAGE_FACTOR = 100
+WEI_IN_ETH = 10**18  # 1 ETH = 10^18 wei
+
+NA = "N/A"
+
+
+class FetchPerformanceSummaryBehaviour(
+    MemeooorrBaseBehaviour,
+):
+    """A behaviour to fetch and store the agent performance summary file."""
+
+    matching_round = FetchPerformanceDataRound
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize Behaviour."""
+        super().__init__(**kwargs)
+        self._agent_performance_summary: Optional[AgentPerformanceSummary] = None
+
+    @property
+    def shared_state(self) -> SharedState:
+        """Return the shared state."""
+        return cast(SharedState, self.context.state)
+
+    @property
+    def params(self) -> AgentPerformanceSummaryParams:
+        """Return the skill params."""
+        return cast(AgentPerformanceSummaryParams, self.context.params)
+
+    def _get_total_likes_and_retweets(self) -> Generator:
+        """Get total likes and retweets from Twitter activity over the last prediction market duration."""
+        yield from self.init_own_twitter_details()
+
+        self.shared_state.twitter_id = "1934591152042479617"
+
+        response: List[Dict] | Dict = yield from self._call_tweepy(
+            method="get_user_tweets_with_public_metrics",
+            **{
+                "user_id": self.shared_state.twitter_id,
+            },
+        )
+        if isinstance(response, dict) and "error" in response:
+            self.context.logger.warning(
+                f"Could not fetch tweets for user ID {self.shared_state.twitter_id}: {response['error']}"
+            )
+            return None, None
+
+        all_tweets: List[Dict] = response
+        total_likes = 0
+        total_impressions = 0
+        for tweet in all_tweets:
+            total_likes += tweet.get("like_count", 0)
+            total_impressions += tweet.get("impression_count", 0)
+
+        return total_likes, total_impressions
+
+    def should_fetch_metrics_again(self) -> bool:
+        """Check if we should fetch the metrics again based on the TTL."""
+        existing_data = self.shared_state.read_existing_performance_summary()
+        if not existing_data.timestamp:
+            self.context.logger.info("No existing data found.")
+            return True
+
+        if any(metric.value == NA for metric in existing_data.metrics):
+            self.context.logger.info("Existing data has N/A metrics.")
+            return True
+        if (
+            existing_data.timestamp + self.params.performance_summary_ttl
+            > self.shared_state.synced_timestamp
+        ):
+            self.context.logger.info(
+                "Agent performance summary was updated recently. Skipping to avoid rate limits."
+            )
+            return False
+        return True
+
+    def _fetch_agent_performance_summary(self) -> Generator:
+        """Fetch the agent performance summary"""
+        current_timestamp = self.shared_state.synced_timestamp
+
+        total_likes, total_impressions = yield from self._get_total_likes_and_retweets()
+
+        metrics = []
+
+        metrics.append(
+            AgentPerformanceMetrics(
+                name="Total Impressions",
+                is_primary=True,
+                description="Total number of tweet impressions overall",
+                value=str(total_impressions) if total_impressions is not None else NA,
+            )
+        )
+
+        metrics.append(
+            AgentPerformanceMetrics(
+                name="Total Likes",
+                is_primary=False,
+                description="Total number of likes overall",
+                value=str(total_likes) if total_likes is not None else NA,
+            )
+        )
+
+        self._agent_performance_summary = AgentPerformanceSummary(
+            timestamp=current_timestamp, metrics=metrics, agent_behavior=None
+        )
+
+    def _save_agent_performance_summary(
+        self, agent_performance_summary: AgentPerformanceSummary
+    ) -> None:
+        """Save the agent performance summary to a file."""
+        existing_data = self.shared_state.read_existing_performance_summary()
+        agent_performance_summary.agent_behavior = existing_data.agent_behavior
+        self.shared_state.overwrite_performance_summary(agent_performance_summary)
+
+    def async_act(self) -> Generator:
+        """Do the action."""
+        if not self.params.is_agent_performance_summary_enabled:
+            self.context.logger.info(
+                "Agent performance summary is disabled. Skipping fetch and save."
+            )
+            payload = FetchPerformanceDataPayload(
+                sender=self.context.agent_address,
+                vote=False,
+            )
+            yield from self.finish_behaviour(payload)
+            return
+
+        if not self.should_fetch_metrics_again():
+            payload = FetchPerformanceDataPayload(
+                sender=self.context.agent_address,
+                vote=False,
+            )
+            yield from self.finish_behaviour(payload)
+            return
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+
+            yield from self._fetch_agent_performance_summary()
+
+            success = all(
+                metric.value != NA for metric in self._agent_performance_summary.metrics
+            )
+            if not success:
+                self.context.logger.warning(
+                    "Agent performance summary could not be fetched. Saving default values"
+                )
+            self._save_agent_performance_summary(self._agent_performance_summary)
+            payload = FetchPerformanceDataPayload(
+                sender=self.context.agent_address,
+                vote=success,
+            )
+
+        yield from self.finish_behaviour(payload)
+
+    def finish_behaviour(self, payload: BaseTxPayload) -> Generator:
+        """Finish the behaviour."""
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
+
+        self.set_done()
+
+
+class AgentPerformanceSummaryRoundBehaviour(AbstractRoundBehaviour):
+    """This behaviour manages the consensus stages for the AgentPerformanceSummary behaviour."""
+
+    initial_behaviour_cls = FetchPerformanceSummaryBehaviour
+    abci_app_cls = AgentPerformanceSummaryAbciApp
+    behaviours: Set[Type[BaseBehaviour]] = {FetchPerformanceSummaryBehaviour}  # type: ignore

--- a/packages/valory/skills/agent_performance_summary_abci/behaviours.py
+++ b/packages/valory/skills/agent_performance_summary_abci/behaviours.py
@@ -84,8 +84,6 @@ class FetchPerformanceSummaryBehaviour(
         """Get total likes and retweets from Twitter activity over the last prediction market duration."""
         yield from self.init_own_twitter_details()
 
-        self.shared_state.twitter_id = "1934591152042479617"
-
         response: List[Dict] | Dict = yield from self._call_tweepy(
             method="get_user_tweets_with_public_metrics",
             **{

--- a/packages/valory/skills/agent_performance_summary_abci/dialogues.py
+++ b/packages/valory/skills/agent_performance_summary_abci/dialogues.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the classes required for dialogue management."""
+
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogue as BaseAbciDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogues as BaseAbciDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogue as BaseContractApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogues as BaseContractApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogue as BaseHttpDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogues as BaseHttpDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    IpfsDialogue as BaseIpfsDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    IpfsDialogues as BaseIpfsDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogue as BaseLedgerApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogues as BaseLedgerApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogue as BaseSigningDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogues as BaseSigningDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogue as BaseTendermintDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogues as BaseTendermintDialogues,
+)
+
+
+AbciDialogue = BaseAbciDialogue
+AbciDialogues = BaseAbciDialogues
+
+
+HttpDialogue = BaseHttpDialogue
+HttpDialogues = BaseHttpDialogues
+
+
+SigningDialogue = BaseSigningDialogue
+SigningDialogues = BaseSigningDialogues
+
+
+LedgerApiDialogue = BaseLedgerApiDialogue
+LedgerApiDialogues = BaseLedgerApiDialogues
+
+
+ContractApiDialogue = BaseContractApiDialogue
+ContractApiDialogues = BaseContractApiDialogues
+
+TendermintDialogue = BaseTendermintDialogue
+TendermintDialogues = BaseTendermintDialogues
+
+
+IpfsDialogue = BaseIpfsDialogue
+IpfsDialogues = BaseIpfsDialogues

--- a/packages/valory/skills/agent_performance_summary_abci/fsm_specification.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/fsm_specification.yaml
@@ -1,0 +1,21 @@
+alphabet_in:
+- DONE
+- FAIL
+- NONE
+- NO_MAJORITY
+- ROUND_TIMEOUT
+default_start_state: FetchPerformanceDataRound
+final_states:
+- FinishedFetchPerformanceDataRound
+label: AgentPerformanceSummaryAbciApp
+start_states:
+- FetchPerformanceDataRound
+states:
+- FetchPerformanceDataRound
+- FinishedFetchPerformanceDataRound
+transition_func:
+    (FetchPerformanceDataRound, DONE): FinishedFetchPerformanceDataRound
+    (FetchPerformanceDataRound, FAIL): FinishedFetchPerformanceDataRound
+    (FetchPerformanceDataRound, NONE): FetchPerformanceDataRound
+    (FetchPerformanceDataRound, NO_MAJORITY): FetchPerformanceDataRound
+    (FetchPerformanceDataRound, ROUND_TIMEOUT): FinishedFetchPerformanceDataRound

--- a/packages/valory/skills/agent_performance_summary_abci/handlers.py
+++ b/packages/valory/skills/agent_performance_summary_abci/handlers.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""This module contains the handlers for the 'agent_performance_summary' skill."""
+
+from packages.valory.skills.abstract_round_abci.handlers import ABCIRoundHandler
+from packages.valory.skills.abstract_round_abci.handlers import (
+    ContractApiHandler as BaseContractApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    HttpHandler as BaseHttpHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    IpfsHandler as BaseIpfsHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    LedgerApiHandler as BaseLedgerApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    SigningHandler as BaseSigningHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    TendermintHandler as BaseTendermintHandler,
+)
+
+
+AgentPerformanceSummaryABCIHandler = ABCIRoundHandler
+HttpHandler = BaseHttpHandler
+SigningHandler = BaseSigningHandler
+LedgerApiHandler = BaseLedgerApiHandler
+ContractApiHandler = BaseContractApiHandler
+TendermintHandler = BaseTendermintHandler
+IpfsHandler = BaseIpfsHandler

--- a/packages/valory/skills/agent_performance_summary_abci/models.py
+++ b/packages/valory/skills/agent_performance_summary_abci/models.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the models for the skill."""
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type, cast
+
+from packages.dvilela.skills.memeooorr_abci.models import SharedState as BaseSharedState
+from packages.valory.skills.abstract_round_abci.base import AbciApp
+from packages.valory.skills.abstract_round_abci.models import BaseParams
+from packages.valory.skills.agent_performance_summary_abci.rounds import (
+    AgentPerformanceSummaryAbciApp,
+)
+
+
+AGENT_PERFORMANCE_SUMMARY_FILE = "agent_performance.json"
+
+
+@dataclass
+class AgentPerformanceMetrics:
+    """Agent performance metrics."""
+
+    name: str
+    is_primary: bool
+    value: str  # eg. "75%"
+    description: Optional[str] = (
+        None  # Can have HTML tags like <b>bold</b> or <i>italic</i>
+    )
+
+
+@dataclass
+class AgentPerformanceSummary:
+    """
+    Agent performance summary.
+
+    - If the agent has any activity, fields will be filled.
+    - Otherwise, initial state with nulls and empty arrays.
+    """
+
+    timestamp: Optional[int] = None  # UNIX timestamp (in seconds, UTC)
+    metrics: List[AgentPerformanceMetrics] = field(default_factory=list)
+    agent_behavior: Optional[str] = None
+
+    @staticmethod
+    def from_dict(data: dict) -> "AgentPerformanceSummary":
+        data["metrics"] = [
+            AgentPerformanceMetrics(**m) for m in data.get("metrics", [])
+        ]
+        return AgentPerformanceSummary(**data)
+
+
+class AgentPerformanceSummaryParams(BaseParams):
+    """Agent Performance Summary's parameters."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the parameters' object."""
+        self.store_path: Path = self.get_store_path(kwargs)
+        self.is_agent_performance_summary_enabled: bool = self._ensure(
+            "is_agent_performance_summary_enabled", kwargs, bool
+        )
+        self.performance_summary_ttl: int = self._ensure(
+            "performance_summary_ttl", kwargs, int
+        )
+        super().__init__(*args, **kwargs)
+
+    def get_store_path(self, kwargs: Dict) -> Path:
+        """Get the path of the store."""
+        path = kwargs.get("store_path", "")
+        # check if path exists, and we can write to it
+        if (
+            not os.path.isdir(path)
+            or not os.access(path, os.W_OK)
+            or not os.access(path, os.R_OK)
+        ):
+            raise ValueError(
+                f"Policy store path {path!r} is not a directory or is not writable."
+            )
+        return Path(path)
+
+
+class SharedState(BaseSharedState):
+    """Keep the current shared state of the skill."""
+
+    abci_app_cls: Type[AbciApp] = AgentPerformanceSummaryAbciApp
+
+    @property
+    def params(self) -> AgentPerformanceSummaryParams:
+        """Return the params."""
+        return cast(AgentPerformanceSummaryParams, self.context.params)
+
+    @property
+    def synced_timestamp(self) -> int:
+        """Return the synchronized timestamp across the agents."""
+        return int(
+            self.context.state.round_sequence.last_round_transition_timestamp.timestamp()
+        )
+
+    def read_existing_performance_summary(self) -> AgentPerformanceSummary:
+        """Read the existing agent performance summary from a file."""
+        file_path = self.params.store_path / AGENT_PERFORMANCE_SUMMARY_FILE
+
+        try:
+            with open(file_path, "r") as f:
+                existing_data = AgentPerformanceSummary.from_dict(json.load(f))
+            return existing_data
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            self.context.logger.warning(
+                f"Could not read existing agent performance summary: {e}"
+            )
+            return AgentPerformanceSummary()
+
+    def overwrite_performance_summary(self, summary: AgentPerformanceSummary) -> None:
+        """Write the agent performance summary to a file."""
+        file_path = self.params.store_path / AGENT_PERFORMANCE_SUMMARY_FILE
+
+        with open(file_path, "w") as f:
+            json.dump(asdict(summary), f, indent=4)
+
+    def update_agent_behavior(self, behavior: str) -> None:
+        """Update the agent behavior in agent performance template file."""
+        existing_data = self.read_existing_performance_summary()
+        existing_data.agent_behavior = behavior
+        existing_data.timestamp = self.synced_timestamp
+        self.overwrite_performance_summary(existing_data)

--- a/packages/valory/skills/agent_performance_summary_abci/payloads.py
+++ b/packages/valory/skills/agent_performance_summary_abci/payloads.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the transaction payloads for the fetch performance summary abci."""
+
+from dataclasses import dataclass
+
+from packages.valory.skills.abstract_round_abci.base import BaseTxPayload
+
+
+@dataclass(frozen=True)
+class FetchPerformanceDataPayload(BaseTxPayload):
+    """Represents a transaction payload for the performance summary."""
+
+    vote: bool

--- a/packages/valory/skills/agent_performance_summary_abci/rounds.py
+++ b/packages/valory/skills/agent_performance_summary_abci/rounds.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the rounds for the agent performance summary ABCI application."""
+
+from abc import ABC
+from enum import Enum
+from typing import Dict, Set, Type
+
+from packages.valory.skills.abstract_round_abci.base import (
+    AbciApp,
+    AbciAppTransitionFunction,
+    AbstractRound,
+    AppState,
+    BaseSynchronizedData,
+    DegenerateRound,
+    VotingRound,
+    get_name,
+)
+from packages.valory.skills.agent_performance_summary_abci.payloads import (
+    FetchPerformanceDataPayload,
+)
+
+
+class Event(Enum):
+    """Events triggering state transitions in the Agent Performance Summary ABCI app."""
+
+    DONE = "done"
+    NONE = "none"
+    FAIL = "fail"
+    ROUND_TIMEOUT = "round_timeout"
+    NO_MAJORITY = "no_majority"
+
+
+class FetchPerformanceDataRound(VotingRound):
+    """A round for fetching and saving Agent Performance summary."""
+
+    payload_class = FetchPerformanceDataPayload
+    synchronized_data_class = BaseSynchronizedData
+    done_event = Event.DONE
+    negative_event = Event.FAIL
+    none_event = Event.NONE
+    no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(BaseSynchronizedData.participant_to_votes)
+
+
+class FinishedFetchPerformanceDataRound(DegenerateRound, ABC):
+    """A terminal round indicating that performance data collection is complete."""
+
+
+class AgentPerformanceSummaryAbciApp(AbciApp[Event]):  # pylint: disable=too-few-public-methods
+    """AgentPerformanceSummaryAbciApp
+
+    Initial round: FetchPerformanceDataRound
+
+    Initial states: {FetchPerformanceDataRound}
+
+    Transition states:
+        0. FetchPerformanceDataRound
+            - done: 1.
+            - none: 0.
+            - fail: 1.
+            - round timeout: 1.
+            - no majority: 0.
+        1. FinishedFetchPerformanceDataRound
+
+    Final states: {FinishedFetchPerformanceDataRound}
+
+    Timeouts:
+        round timeout: 30.0
+    """
+
+    initial_round_cls: Type[AbstractRound] = FetchPerformanceDataRound
+    transition_function: AbciAppTransitionFunction = {
+        FetchPerformanceDataRound: {
+            Event.DONE: FinishedFetchPerformanceDataRound,
+            Event.NONE: FetchPerformanceDataRound,
+            Event.FAIL: FinishedFetchPerformanceDataRound,
+            Event.ROUND_TIMEOUT: FinishedFetchPerformanceDataRound,
+            Event.NO_MAJORITY: FetchPerformanceDataRound,
+        },
+        FinishedFetchPerformanceDataRound: {},
+    }
+    final_states: Set[AppState] = {
+        FinishedFetchPerformanceDataRound,
+    }
+    event_to_timeout: Dict[Event, float] = {
+        Event.ROUND_TIMEOUT: 30.0,
+    }
+    db_pre_conditions: Dict[AppState, Set[str]] = {FetchPerformanceDataRound: set()}
+    db_post_conditions: Dict[AppState, Set[str]] = {
+        FinishedFetchPerformanceDataRound: set(),
+    }

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -1,0 +1,59 @@
+name: agent_performance_summary_abci
+version: 0.1.0
+description: Agent Performance summary skill for Predict agent
+author: valory
+type: skill
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeifrlephtnp4zdqlmovozy25ztjsfyvopm2pinkzyxtc65hmg53b5m
+  behaviours.py: bafybeiebxuvfmi5krrdd2sh46qbzk5e2572iwtf37z3uvmnifc5qbwlxbe
+  dialogues.py: bafybeihqnuqcqbrxzedx5iq5bkjg7r54f2bzcwu4frwtym3o4cggscx36m
+  fsm_specification.yaml: bafybeieh2wmnqfkrpfeyvkoojbvd7tbjg36edhnisi6mycdjugymgut3vi
+  handlers.py: bafybeic32gqov34qy535ja27cvwid2nqitrzvp3h6eawq5gs5bkbq54u5u
+  models.py: bafybeibd62ccunfckdoj6543sjt7hoo3tkm5ab7lkjwzzrshok3spmmoay
+  payloads.py: bafybeibrfby2hkt3ljy4qpkshx5shjozxu2jfw4wpzggqvejce4nridyhe
+  rounds.py: bafybeifkvdespxwx5m2kvnaiidplx6brotpp3xiay3xahqmlasq7uvxcxe
+  utils.py: bafybeih57iz6z7tnt56sj4ob64ptminodeduj7v33yncznp756y3br4nqm
+fingerprint_ignore_patterns: []
+contracts: []
+skills:
+- valory/abstract_round_abci:0.1.0:bafybeifsuf7sh5vlugnqinbqe2f7vnssuqyxcrzqgotohhwqewyjeibneu
+- dvilela/memeooorr_abci:0.1.0:bafybeial2bolrhn4ro2zex5c5rlg4lsdo22gti5eutc5cgdznypqxblj2m
+handlers:
+  abci:
+    args: {}
+    class_name: AgentPerformanceSummaryABCIHandler
+  contract_api:
+    args: {}
+    class_name: ContractApiHandler
+  http:
+    args: {}
+    class_name: HttpHandler
+  ipfs:
+    args: {}
+    class_name: IpfsHandler
+  ledger_api:
+    args: {}
+    class_name: LedgerApiHandler
+  signing:
+    args: {}
+    class_name: SigningHandler
+  tendermint:
+    args: {}
+    class_name: TendermintHandler
+behaviours: {}
+models:
+  state:
+    args: {}
+    class_name: SharedState
+  params:
+    args:
+      store_path: /data/
+      is_agent_performance_summary_enabled: true
+      performance_summary_ttl: 1800
+    class_name: AgentPerformanceSummaryParams
+dependencies: {}
+is_abstract: true
+connections: []
+protocols: []

--- a/scripts/aea-config-replace.py
+++ b/scripts/aea-config-replace.py
@@ -76,6 +76,9 @@ PATH_TO_VAR = {
     "models/params/args/use_x402": "USE_X402",
     "config/use_x402": "USE_X402",
     "config/genai_x402_server_base_url": "GENAI_X402_SERVER_BASE_URL",
+    # Agent Performance Summary
+    "models/params/args/is_agent_performance_summary_enabled": "IS_AGENT_PERFORMANCE_SUMMARY_ENABLED",
+    "models/params/args/performance_summary_ttl": "PERFORMANCE_SUMMARY_TTL",
 }
 
 CONFIG_REGEX = r"\${.*?:(.*)}"


### PR DESCRIPTION
This PR
- Adds get all user tweets method to tweepy connection
- Adds skill to fetch and save performance summary data
  - Adapted from https://github.com/valory-xyz/trader
- Modifies init_own_twitter_details to also support running when AgentsDB is not initialized
  - Required as we need twitter id for performance summary
- Added logic to skip fetching metrics based on recency
  - Currently will only fetch after every 30 mins
  - To prevent twitter rate limits

PR Chain:
1. https://github.com/dvilelaf/meme-ooorr/pull/279
2. https://github.com/dvilelaf/meme-ooorr/pull/280
3. https://github.com/dvilelaf/meme-ooorr/pull/281
4. https://github.com/dvilelaf/meme-ooorr/pull/282
5. https://github.com/dvilelaf/meme-ooorr/pull/283
6. https://github.com/dvilelaf/meme-ooorr/pull/284
7. https://github.com/dvilelaf/meme-ooorr/pull/289
8. https://github.com/dvilelaf/meme-ooorr/pull/290

Note: CI would be fixed in the very last PR. (This PR doesn't point to main)